### PR TITLE
(SIMP-2267) Replace Integer types with Strings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ group :test do
   gem 'metadata-json-lint'
   gem 'puppet-lint-empty_string-check',   :require => false
   gem 'puppet-lint-trailing_comma-check', :require => false
+  gem 'puppet-strings'
   gem 'simp-rspec-puppet-facts', ENV.fetch('SIMP_RSPEC_PUPPET_FACTS_VERSION', '~> 1.3')
   gem 'simp-rake-helpers', ENV.fetch('SIMP_RAKE_HELPERS_VERSION', '~> 3.0')
 end
@@ -24,7 +25,6 @@ group :development do
   gem 'travis-lint'
   gem 'travish'
   gem 'puppet-blacksmith'
-  gem 'puppet-strings'
   gem 'guard-rake'
   gem 'pry'
   gem 'pry-doc'

--- a/manifests/dns.pp
+++ b/manifests/dns.pp
@@ -23,8 +23,8 @@
 # @author SIMP Team - https://simp-project.com
 #
 class simp_options::dns (
- Array[String] $search = [],
- Array[String] $servers = []
+  Array[String] $search = [],
+  Array[String] $servers = []
 ){
- validate_net_list($servers)
+  validate_net_list($servers)
 }

--- a/manifests/puppet.pp
+++ b/manifests/puppet.pp
@@ -14,7 +14,7 @@
 class simp_options::puppet (
   String $server,
   String $ca,
-  Integer $ca_port = 8141
+  String $ca_port = '8141'
 ){
   validate_net_list($server)
   validate_net_list($ca)

--- a/manifests/puppet.pp
+++ b/manifests/puppet.pp
@@ -14,7 +14,7 @@
 class simp_options::puppet (
   String $server,
   String $ca,
-  String $ca_port = '8141'
+  Simplib::Compat::Integer $ca_port = '8141'
 ){
   validate_net_list($server)
   validate_net_list($ca)

--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -16,7 +16,7 @@
 #
 class simp_options::rsync (
   String $server  = '127.0.0.1',
-  String $timeout = '1'
+  Simplib::Compat::Integer $timeout = '1'
 ){
   validate_net_list($server)
 }

--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -15,8 +15,8 @@
 # @author SIMP Team - https://simp-project.com
 #
 class simp_options::rsync (
-  String $server   = '127.0.0.1',
-  Integer $timeout = 1
+  String $server  = '127.0.0.1',
+  String $timeout = '1'
 ){
   validate_net_list($server)
 }


### PR DESCRIPTION
For backward compatibility, change simp_options::rsync::timeout and
simp_options::puppet::ca_port to be String parameters.

SIMP-2267 #close