### PR TITLE
(SIMP-2276) Rework simp_options::openssl::cipher_suites

### DIFF
--- a/data/fips_enabled/is_.yaml
+++ b/data/fips_enabled/is_.yaml
@@ -1,1 +1,0 @@
-is_false.yaml

--- a/data/fips_enabled/is_false.yaml
+++ b/data/fips_enabled/is_false.yaml
@@ -1,4 +1,0 @@
----
-simp_options::openssl::cipher_suite :
-  - "DEFAULT"
-  - "!MEDIUM"

--- a/data/fips_enabled/is_true.yaml
+++ b/data/fips_enabled/is_true.yaml
@@ -1,6 +1,0 @@
----
-simp_options::openssl::cipher_suite :
-# FIPS is an unadvertised cipher suite.  Run 'openssl ciphers FIPS' to inspect.
- - "FIPS"
- - "!LOW"
-

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -2,8 +2,5 @@
 version: 4
 datadir: data
 hierarchy:
-  - name: "fips_enabled"
-    backend: yaml
-    path: "fips_enabled/is_%{facts.fips_enabled}"
   - name: "ldap"
     backend: yaml

--- a/manifests/dns.pp
+++ b/manifests/dns.pp
@@ -26,5 +26,6 @@ class simp_options::dns (
   Array[String] $search = [],
   Array[String] $servers = []
 ){
+  assert_private()
   validate_net_list($servers)
 }

--- a/manifests/ldap.pp
+++ b/manifests/ldap.pp
@@ -53,6 +53,7 @@ class simp_options::ldap (
   String $master,
   Array[String] $uri
 ){
+  assert_private()
   validate_uri_list($master,['ldap','ldaps'])
   validate_uri_list($uri,['ldap','ldaps'])
 }

--- a/manifests/ntpd.pp
+++ b/manifests/ntpd.pp
@@ -13,5 +13,6 @@
 class simp_options::ntpd (
   Array[String] $servers = []
 ){
+  assert_private()
   validate_net_list($servers)
 }

--- a/manifests/openssl.pp
+++ b/manifests/openssl.pp
@@ -5,14 +5,12 @@
 #
 # @param cipher_suite The default ciphers to use in openssl.
 #
-#   * The default value is based on the ``fips_enabled`` fact. See the Hiera
-#     defaults in ``simp_options/data/fips_enabled``.
-#
 # @see https://wiki.openssl.org/index.php/Command_Line_Utilities#ciphers OpenSSL Ciphers Command
 #
 # @author SIMP Team - https://simp-project.com
 #
 class simp_options::openssl (
-  Array[String] $cipher_suite
-){
+  Array[String] $cipher_suite = $::simp_options::openssl::params::cipher_suite
+) inherits simp_options::openssl::params {
+  assert_private()
 }

--- a/manifests/openssl/params.pp
+++ b/manifests/openssl/params.pp
@@ -1,0 +1,15 @@
+# simp_options::openssl::params class
+#
+# Sets appropriate openssl cipher suite based on whether
+# FIPS-mode is desired or the system is already in FIPS mode.
+#
+class simp_options::openssl::params (
+) {
+  assert_private()
+  include '::simp_options'
+  if $::simp_options::fips or $facts['fips_enabled'] {
+    $cipher_suite = ['FIPS', '!LOW']
+  } else {
+    $cipher_suite = ['DEFAULT', '!MEDIUM']
+  }
+}

--- a/manifests/puppet.pp
+++ b/manifests/puppet.pp
@@ -16,6 +16,7 @@ class simp_options::puppet (
   String $ca,
   Stdlib::Compat::Integer $ca_port = '8141'
 ){
+  assert_private()
   validate_net_list($server)
   validate_net_list($ca)
 }

--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -18,5 +18,6 @@ class simp_options::rsync (
   String $server  = '127.0.0.1',
   Stdlib::Compat::Integer $timeout = '1'
 ){
+  assert_private()
   validate_net_list($server)
 }

--- a/manifests/syslog.pp
+++ b/manifests/syslog.pp
@@ -13,6 +13,7 @@ class simp_options::syslog (
   Array[String] $log_servers          = [],
   Array[String] $failover_log_servers = []
 ){
+  assert_private()
   validate_net_list($log_servers)
   validate_net_list($failover_log_servers)
 }

--- a/spec/classes/dns_spec.rb
+++ b/spec/classes/dns_spec.rb
@@ -1,18 +1,14 @@
 require 'spec_helper'
 
-describe 'simp_options::dns' do
+describe 'simp_options' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
 
       context "on #{os}" do
         let(:facts){ facts }
 
-        context 'default parameters' do
-          it { is_expected.to compile.with_all_deps }
-        end
-
-        context 'invalid servers' do
-          let(:params){{ :servers => ['1.2.3.400'] }}
+        context 'invalid simp_options::dns::servers' do
+          let(:hieradata) { 'simp_options_with_invalid_dns_servers'}
           it { is_expected.not_to compile.with_all_deps }
         end
       end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-shared_examples_for  'a simp_opt class' do
+shared_examples_for  'a simp_options class' do
   it { is_expected.to compile.with_all_deps }
   it { is_expected.to contain_class('simp_options::dns') }
   it { is_expected.to contain_class('simp_options::ntpd') }
@@ -18,20 +18,20 @@ describe 'simp_options' do
 
         context 'default parameters' do
           let(:hieradata) { class_name }
-          it_should_behave_like "a simp_opt class"
+          it_should_behave_like "a simp_options class"
         end
 
         context 'with ldap enabled' do
           let(:hieradata) { "#{class_name}_with_ldap" }
           let(:params){{ :ldap => true }}
-          it_should_behave_like "a simp_opt class"
+          it_should_behave_like "a simp_options class"
           it { is_expected.to contain_class('simp_options::ldap') }
         end
 
         context 'with syslog enabled' do
           let(:hieradata) { class_name }
           let(:params){{ :syslog => true }}
-          it_should_behave_like "a simp_opt class"
+          it_should_behave_like "a simp_options class"
           it { is_expected.to contain_class('simp_options::syslog') }
         end
 

--- a/spec/classes/ldap_spec.rb
+++ b/spec/classes/ldap_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
-describe 'simp_options::ldap' do
+describe 'simp_options' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
 
       context "on #{os}" do
         let(:facts){ facts }
 
-        context 'default parameters' do
+        context 'default parameters for simp_options::ldap' do
           let(:hieradata) { 'simp_options_with_ldap' }
           it { is_expected.to compile.with_all_deps }
           # make sure interpolation of hieradata in modules's data/ is working
@@ -28,15 +28,13 @@ describe 'simp_options::ldap' do
           }
         end
 
-        context 'invalid master' do
-          let(:hieradata) { 'simp_options_with_ldap' }
-          let(:params){{ :master => '1.2.3.400' }}
+        context 'invalid simp_options::ldap::master' do
+          let(:hieradata) { 'simp_options_with_invalid_ldap_master' }
           it { is_expected.not_to compile.with_all_deps }
         end
 
-        context 'invalid uri' do
-          let(:hieradata) { 'simp_options_with_ldap' }
-          let(:params){{ :uri => ['1.2.3.500'] }}
+        context 'invalid simp_options::ldap::uri' do
+          let(:hieradata) { 'simp_options_with_invalid_ldap_uri' }
           it { is_expected.not_to compile.with_all_deps }
         end
       end

--- a/spec/classes/ntpd_spec.rb
+++ b/spec/classes/ntpd_spec.rb
@@ -1,18 +1,14 @@
 require 'spec_helper'
 
-describe 'simp_options::ntpd' do
+describe 'simp_options' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
 
       context "on #{os}" do
         let(:facts){ facts }
 
-        context 'default parameters' do
-          it { is_expected.to compile.with_all_deps }
-        end
-
-        context 'invalid servers' do
-          let(:params){{ :servers => ['1.2.3.400'] }}
+        context 'invalid ntpd servers' do
+          let(:hieradata) { 'simp_options_with_invalid_ntpd_servers'}
           it { is_expected.not_to compile.with_all_deps }
         end
       end

--- a/spec/classes/openssl_spec.rb
+++ b/spec/classes/openssl_spec.rb
@@ -1,12 +1,12 @@
 require 'spec_helper'
 
-describe 'simp_options::openssl' do
+describe 'simp_options' do
   context 'supported operating systems' do
     on_supported_os.each do |os, os_facts|
 
       context "on #{os}" do
 
-        context 'defaults with FIPS enabled' do
+        context 'defaults for simp_options::openssl with FIPS enabled' do
           let(:facts){{ :fips_enabled => true }}
           it { is_expected.to compile.with_all_deps }
           it { 
@@ -16,18 +16,7 @@ describe 'simp_options::openssl' do
           }
         end
 
-        #HACK When fips_enabled fact is false, puppet lookup returns empty string
-        # instead of false.  To workaround this bug, in the module hiera.yaml we set
-        # the path for the fips_enabled module data to 
-        #   "fips_enabled/is_%{facts.fips_enabled}"
-        # instead of 
-        #   "fips_enabled/%{facts.fips_enabled}"
-        #  and populate data/fips_enabled with
-        #   is_true.yaml
-        #   is_false.yaml
-        #   is_.yaml <-- link to is_false.yaml
-        #FIXME When puppet lookup is fixed, remove link and 'is_' prefix.
-        context 'defaults without FIPS enabled' do
+        context 'defaults for simp_options::openssl without FIPS enabled' do
           let(:facts){{ :fips_enabled => false }}
           it { is_expected.to compile.with_all_deps }
           it {

--- a/spec/classes/puppet_spec.rb
+++ b/spec/classes/puppet_spec.rb
@@ -1,24 +1,19 @@
 require 'spec_helper'
 
-describe 'simp_options::puppet' do
+describe 'simp_options' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
 
       context "on #{os}" do
         let(:facts){ facts }
 
-        context 'default parameters' do
-          let(:params) {{ :server => '1.2.3.4', :ca => '2.3.4.5' }}
-          it { is_expected.to compile.with_all_deps }
-        end
-
-        context 'invalid server' do
-          let(:params) {{ :server => '1000.2.3.4', :ca => '2.3.4.5' }}
+        context 'invalid simp_options::puppet::server' do
+          let(:hieradata) { 'simp_options_with_invalid_puppet_server'}
           it { is_expected.not_to compile.with_all_deps}
         end
 
-        context 'invalid ca' do
-          let(:params) {{ :server => '1.2.3.4', :ca => '2.300.4.5' }}
+        context 'invalid simp_options::puppet::ca' do
+          let(:hieradata) { 'simp_options_with_invalid_puppet_ca'}
           it { is_expected.not_to compile.with_all_deps}
         end
       end

--- a/spec/classes/rsync_spec.rb
+++ b/spec/classes/rsync_spec.rb
@@ -1,19 +1,15 @@
 require 'spec_helper'
 
 
-describe 'simp_options::rsync' do
+describe 'simp_options' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
 
       context "on #{os}" do
         let(:facts){ facts }
 
-        context 'default parameters' do
-          it { is_expected.to compile.with_all_deps }
-        end
-
-        context 'invalid server' do
-          let(:params){{ :server => '1.2.3.400' }}
+        context 'invalid simp_options::rsync::server' do
+          let(:hieradata) { 'simp_options_with_invalid_rsync_server'}
           it { is_expected.not_to compile.with_all_deps}
         end
       end

--- a/spec/classes/syslog_spec.rb
+++ b/spec/classes/syslog_spec.rb
@@ -1,24 +1,19 @@
 require 'spec_helper'
 
-
-describe 'simp_options::syslog' do
+describe 'simp_options' do
   context 'supported operating systems' do
     on_supported_os.each do |os, facts|
 
       context "on #{os}" do
         let(:facts){ facts }
 
-        context 'default parameters' do
-          it { is_expected.to compile.with_all_deps }
-        end
-
-        context 'invalid log_servers' do
-          let(:params){{ :log_servers => ['1.2.3.4', '2.3.4.500'] }}
+        context 'invalid simp_options::syslog::log_servers' do
+          let(:hieradata) { 'simp_options_with_invalid_syslog_log_servers'}
           it { is_expected.not_to compile.with_all_deps}
         end
 
-        context 'invalid failover_log_servers' do
-          let(:params){{ :failover_log_servers => ['1.2.300.4', '2.3.4.5'] }}
+        context 'invalid simp_options::syslog::failover_log_servers' do
+          let(:hieradata) { 'simp_options_with_invalid_syslog_failover_log_servers'}
           it { is_expected.not_to compile.with_all_deps}
         end
       end

--- a/spec/fixtures/hieradata/simp_options_with_invalid_dns_servers.yaml
+++ b/spec/fixtures/hieradata/simp_options_with_invalid_dns_servers.yaml
@@ -1,0 +1,5 @@
+---
+simp_options::puppet::server : 'puppet.example.com'
+simp_options::puppet::ca : 'puppet.example.com'
+simp_options::dns::servers :
+ - '1.2.3.400'

--- a/spec/fixtures/hieradata/simp_options_with_invalid_ldap_master.yaml
+++ b/spec/fixtures/hieradata/simp_options_with_invalid_ldap_master.yaml
@@ -8,4 +8,5 @@ simp_options::ldap::bind_hash : '{SSHA}DEADBEEFdeadbeefDEADBEEFdeadbeef'
 simp_options::ldap::sync_pw : 'N0t=@=R#@l=Sync=P@ssw0rd'
 simp_options::ldap::sync_hash : '{SSHA}DeadBeerDeadBeefDeadBeefDeadBeef'
 simp_options::ldap::root_hash : '{SSHA}deadbeefDEADBEEFdeadbeefDEADBEEF'
+simp_options::ldap::master : '1.2.3.400'
 

--- a/spec/fixtures/hieradata/simp_options_with_invalid_ldap_uri.yaml
+++ b/spec/fixtures/hieradata/simp_options_with_invalid_ldap_uri.yaml
@@ -8,4 +8,5 @@ simp_options::ldap::bind_hash : '{SSHA}DEADBEEFdeadbeefDEADBEEFdeadbeef'
 simp_options::ldap::sync_pw : 'N0t=@=R#@l=Sync=P@ssw0rd'
 simp_options::ldap::sync_hash : '{SSHA}DeadBeerDeadBeefDeadBeefDeadBeef'
 simp_options::ldap::root_hash : '{SSHA}deadbeefDEADBEEFdeadbeefDEADBEEF'
-
+simp_options::ldap::uri :
+ - '1.2.3.500'

--- a/spec/fixtures/hieradata/simp_options_with_invalid_ntpd_servers.yaml
+++ b/spec/fixtures/hieradata/simp_options_with_invalid_ntpd_servers.yaml
@@ -1,0 +1,5 @@
+---
+simp_options::puppet::server : 'puppet.example.com'
+simp_options::puppet::ca : 'puppet.example.com'
+simp_options::ntpd::servers :
+ - '1.2.3.400'

--- a/spec/fixtures/hieradata/simp_options_with_invalid_puppet_ca.yaml
+++ b/spec/fixtures/hieradata/simp_options_with_invalid_puppet_ca.yaml
@@ -1,0 +1,3 @@
+---
+simp_options::puppet::server : 'puppet.example.com'
+simp_options::puppet::ca : '600.1.2.3'

--- a/spec/fixtures/hieradata/simp_options_with_invalid_puppet_server.yaml
+++ b/spec/fixtures/hieradata/simp_options_with_invalid_puppet_server.yaml
@@ -1,0 +1,3 @@
+---
+simp_options::puppet::server : '1.500.2.3'
+simp_options::puppet::ca : 'puppet.example.com'

--- a/spec/fixtures/hieradata/simp_options_with_invalid_rsync_server.yaml
+++ b/spec/fixtures/hieradata/simp_options_with_invalid_rsync_server.yaml
@@ -1,0 +1,4 @@
+---
+simp_options::puppet::server : 'puppet.example.com'
+simp_options::puppet::ca : 'puppet.example.com'
+simp_options::rsync::server : '1.2.3.400'

--- a/spec/fixtures/hieradata/simp_options_with_invalid_syslog_failover_log_servers.yaml
+++ b/spec/fixtures/hieradata/simp_options_with_invalid_syslog_failover_log_servers.yaml
@@ -1,0 +1,7 @@
+---
+simp_options::puppet::server : 'puppet.example.com'
+simp_options::puppet::ca : 'puppet.example.com'
+simp_options::syslog : true
+simp_options::syslog::failover_log_servers :
+ - '1.2.300.4'
+ - '2.3.4.5'

--- a/spec/fixtures/hieradata/simp_options_with_invalid_syslog_log_servers.yaml
+++ b/spec/fixtures/hieradata/simp_options_with_invalid_syslog_log_servers.yaml
@@ -1,0 +1,7 @@
+---
+simp_options::puppet::server : 'puppet.example.com'
+simp_options::puppet::ca : 'puppet.example.com'
+simp_options::syslog : true
+simp_options::syslog::log_servers :
+ - '1.2.3.4'
+ - '2.3.4.500'


### PR DESCRIPTION
- Set cipher_suites to FIPS set if either FIPS mode is
  desired or the system is in FIPS mode.
- Make all but simp_options private classes.

SIMP-2276 #close