### PR TITLE
(SIMP-2416) Cleanup simp_options parameter types

### DIFF
--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,0 +1,4 @@
+Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
+Requires: pupmod-puppetlabs-stdlib >= 4.9.0-0
+Requires: pupmod-simp-simplib < 4.0.0-0
+Requires: pupmod-simp-simplib >= 3.1.0-0

--- a/manifests/dns.pp
+++ b/manifests/dns.pp
@@ -23,8 +23,8 @@
 # @author SIMP Team - https://simp-project.com
 #
 class simp_options::dns (
-  Array[String] $search = [],
-  Array[String] $servers = []
+  Array[String]        $search  = [],
+  Array[Simplib::Host] $servers = []
 ){
   assert_private()
   validate_net_list($servers)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,9 +44,8 @@
 #
 # @param pam Whether to include SIMP’s ``::pam`` class SIMP to manage ``PAM``
 #
-# @param pki Dual state 'Stroolean', valid options are True, False, 'simp'.
-#   pki can optionally include SIMP's ``::pki`` class, and optionally use
-#   ``::pki::copy`` to distrtibute PKI certificates to the correct locations.
+# @param pki Whether to include SIMP’s ``::pki`` class and use ``pki::copy`` to
+#   distribute PKI certificates to the correct locations.
 #   If false, don't include SIMP's ``::pki`` class, and don't use ``::pki::copy``.
 #   If true,  don't include SIMP's ``::pki`` class, but use ``::pki::copy``.
 #   If 'simp', include SIMP's ``::pki`` class, and use ``::pki::copy``.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,24 +71,24 @@
 # @author SIMP Team - https://simp-project.com
 #
 class simp_options (
-  Boolean $auditd                           = false,
-  Boolean $clamav                           = false,
-  Boolean $fips                             = false,
-  Boolean $firewall                         = false,
-  Boolean $haveged                          = false,
-  Boolean $ipsec                            = false,
-  Boolean $ipv6                             = false,
-  Boolean $kerberos                         = false,
-  Boolean $ldap                             = false,
-  Boolean $logrotate                        = false,
-  Boolean $pam                              = false,
-  Boolean $pki                              = false,
-  Boolean $selinux                          = false,
-  Boolean $sssd                             = false,
-  Boolean $stunnel                          = false,
-  Boolean $syslog                           = false,
-  Boolean $tcpwrappers                      = false,
-  Array[String] $trusted_nets               = ['127.0.0.1', '::1']
+  Boolean $auditd             = false,
+  Boolean $clamav             = false,
+  Boolean $fips               = false,
+  Boolean $firewall           = false,
+  Boolean $haveged            = false,
+  Boolean $ipsec              = false,
+  Boolean $ipv6               = false,
+  Boolean $kerberos           = false,
+  Boolean $ldap               = false,
+  Boolean $logrotate          = false,
+  Boolean $pam                = false,
+  Boolean $pki                = false,
+  Boolean $selinux            = false,
+  Boolean $sssd               = false,
+  Boolean $stunnel            = false,
+  Boolean $syslog             = false,
+  Boolean $tcpwrappers        = false,
+  Array[String] $trusted_nets = ['127.0.0.1', '::1']
 ){
   validate_net_list($trusted_nets)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,24 +71,24 @@
 # @author SIMP Team - https://simp-project.com
 #
 class simp_options (
-  Boolean          $auditd       = false,
-  Boolean          $clamav       = false,
-  Boolean          $fips         = false,
-  Boolean          $firewall     = false,
-  Boolean          $haveged      = false,
-  Boolean          $ipsec        = false,
-  Boolean          $ipv6         = false,
-  Boolean          $kerberos     = false,
-  Boolean          $ldap         = false,
-  Boolean          $logrotate    = false,
-  Boolean          $pam          = false,
-  Boolean          $pki          = false,
-  Boolean          $selinux      = false,
-  Boolean          $sssd         = false,
-  Boolean          $stunnel      = false,
-  Boolean          $syslog       = false,
-  Boolean          $tcpwrappers  = false,
-  Simplib::Netlist $trusted_nets = ['127.0.0.1', '::1']
+  Boolean                       $auditd       = false,
+  Boolean                       $clamav       = false,
+  Boolean                       $fips         = false,
+  Boolean                       $firewall     = false,
+  Boolean                       $haveged      = false,
+  Boolean                       $ipsec        = false,
+  Boolean                       $ipv6         = false,
+  Boolean                       $kerberos     = false,
+  Boolean                       $ldap         = false,
+  Boolean                       $logrotate    = false,
+  Boolean                       $pam          = false,
+  Variant[Boolean,Enum['simp']] $pki          = false,
+  Boolean                       $selinux      = false,
+  Boolean                       $sssd         = false,
+  Boolean                       $stunnel      = false,
+  Boolean                       $syslog       = false,
+  Boolean                       $tcpwrappers  = false,
+  Simplib::Netlist              $trusted_nets = ['127.0.0.1', '::1']
 ){
   validate_net_list($trusted_nets)
 
@@ -100,6 +100,10 @@ class simp_options (
 
   if $ldap {
     include '::simp_options::ldap'
+  }
+
+  if $pki {
+    include '::simp_options::pki'
   }
 
   if $syslog {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,24 +71,24 @@
 # @author SIMP Team - https://simp-project.com
 #
 class simp_options (
-  Boolean $auditd             = false,
-  Boolean $clamav             = false,
-  Boolean $fips               = false,
-  Boolean $firewall           = false,
-  Boolean $haveged            = false,
-  Boolean $ipsec              = false,
-  Boolean $ipv6               = false,
-  Boolean $kerberos           = false,
-  Boolean $ldap               = false,
-  Boolean $logrotate          = false,
-  Boolean $pam                = false,
-  Boolean $pki                = false,
-  Boolean $selinux            = false,
-  Boolean $sssd               = false,
-  Boolean $stunnel            = false,
-  Boolean $syslog             = false,
-  Boolean $tcpwrappers        = false,
-  Array[String] $trusted_nets = ['127.0.0.1', '::1']
+  Boolean          $auditd       = false,
+  Boolean          $clamav       = false,
+  Boolean          $fips         = false,
+  Boolean          $firewall     = false,
+  Boolean          $haveged      = false,
+  Boolean          $ipsec        = false,
+  Boolean          $ipv6         = false,
+  Boolean          $kerberos     = false,
+  Boolean          $ldap         = false,
+  Boolean          $logrotate    = false,
+  Boolean          $pam          = false,
+  Boolean          $pki          = false,
+  Boolean          $selinux      = false,
+  Boolean          $sssd         = false,
+  Boolean          $stunnel      = false,
+  Boolean          $syslog       = false,
+  Boolean          $tcpwrappers  = false,
+  Simplib::Netlist $trusted_nets = ['127.0.0.1', '::1']
 ){
   validate_net_list($trusted_nets)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -44,8 +44,12 @@
 #
 # @param pam Whether to include SIMP’s ``::pam`` class SIMP to manage ``PAM``
 #
-# @param pki Whether to include SIMP's ``::pki`` class and use ``::pki::copy``
-#   to distribute PKI certificates to the correct locations
+# @param pki Dual state 'Stroolean', valid options are True, False, 'simp'.
+#   pki can optionally include SIMP's ``::pki`` class, and optionally use
+#   ``::pki::copy`` to distrtibute PKI certificates to the correct locations.
+#   If false, don't include SIMP's ``::pki`` class, and don't use ``::pki::copy``.
+#   If true,  don't include SIMP's ``::pki`` class, but use ``::pki::copy``.
+#   If 'simp', include SIMP's ``::pki`` class, and use ``::pki::copy``.
 #
 # @param selinux Whether to include SIMP's ``::selinux`` class (which
 #   effectively manages the ``SELinux`` enforcement and mode) and manage

--- a/manifests/ldap.pp
+++ b/manifests/ldap.pp
@@ -41,17 +41,17 @@
 # @author SIMP Team - https://simp-project.com
 #
 class simp_options::ldap (
-  String $base_dn,
-  String $bind_dn,
-  String $bind_pw,
-  String $bind_hash,
-  String $sync_dn,
-  String $sync_pw,
-  String $sync_hash,
-  String $root_dn,
-  String $root_hash,
-  String $master,
-  Array[String] $uri
+  String              $base_dn,
+  String              $bind_dn,
+  String              $bind_pw,
+  String              $bind_hash,
+  String              $sync_dn,
+  String              $sync_pw,
+  String              $sync_hash,
+  String              $root_dn,
+  String              $root_hash,
+  Simplib::URI        $master,
+  Array[Simplib::URI] $uri
 ){
   assert_private()
   validate_uri_list($master,['ldap','ldaps'])

--- a/manifests/ntpd.pp
+++ b/manifests/ntpd.pp
@@ -11,7 +11,7 @@
 # @author SIMP Team - https://simp-project.com
 #
 class simp_options::ntpd (
-  Array[String] $servers = []
+  Array[Simplib::Host] $servers = []
 ){
   assert_private()
   validate_net_list($servers)

--- a/manifests/pki.pp
+++ b/manifests/pki.pp
@@ -1,0 +1,15 @@
+#
+# simp_options::pki class
+#
+# Sets up global PKI configuration variables
+#
+# @param source The source location for PKI certificates.  This is the source
+#   directory for pki::copy.
+#
+# @author SIMP Team - https://simp-project.com
+#
+class simp_options::pki (
+  Stdlib::Absolutepath $source = '/etc/pki/simp'
+){
+  assert_private()
+}

--- a/manifests/puppet.pp
+++ b/manifests/puppet.pp
@@ -12,9 +12,9 @@
 # @author SIMP Team - https://simp-project.com
 #
 class simp_options::puppet (
-  String $server,
-  String $ca,
-  Stdlib::Compat::Integer $ca_port = '8141'
+  Simplib::Host $server,
+  Simplib::Host $ca,
+  Simplib::Port $ca_port = 8141
 ){
   assert_private()
   validate_net_list($server)

--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -15,8 +15,8 @@
 # @author SIMP Team - https://simp-project.com
 #
 class simp_options::rsync (
-  String $server  = '127.0.0.1',
-  Stdlib::Compat::Integer $timeout = '1'
+  Simplib::Host $server  = '127.0.0.1',
+  Integer       $timeout = 1
 ){
   assert_private()
   validate_net_list($server)

--- a/manifests/syslog.pp
+++ b/manifests/syslog.pp
@@ -10,8 +10,8 @@
 # @author SIMP Team - https://simp-project.com
 #
 class simp_options::syslog (
-  Array[String] $log_servers          = [],
-  Array[String] $failover_log_servers = []
+  Array[Simplib::Host] $log_servers          = [],
+  Array[Simplib::Host] $failover_log_servers = []
 ){
   assert_private()
   validate_net_list($log_servers)

--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
+      "version_requirement": ">= 3.1.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/dns_spec.rb
+++ b/spec/classes/dns_spec.rb
@@ -7,6 +7,15 @@ describe 'simp_options' do
       context "on #{os}" do
         let(:facts){ facts }
 
+        context 'default parameters for simp_options::dns' do
+          let(:hieradata) { 'simp_options'}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('simp_options::dns').with(
+            :search => [],
+            :servers => []
+          ) }
+        end
+
         context 'invalid simp_options::dns::servers' do
           let(:hieradata) { 'simp_options_with_invalid_dns_servers'}
           it { is_expected.not_to compile.with_all_deps }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -28,6 +28,20 @@ describe 'simp_options' do
           it { is_expected.to contain_class('simp_options::ldap') }
         end
 
+        context 'with pki=true' do
+          let(:hieradata) { "#{class_name}_with_pki_true" }
+          let(:params){{ :pki => true }}
+          it_should_behave_like "a simp_options class"
+          it { is_expected.to contain_class('simp_options::pki') }
+        end
+
+        context 'with pki=simp' do
+          let(:hieradata) { "#{class_name}_with_pki_simp" }
+          let(:params){{ :pki => true }}
+          it_should_behave_like "a simp_options class"
+          it { is_expected.to contain_class('simp_options::pki') }
+        end
+
         context 'with syslog enabled' do
           let(:hieradata) { class_name }
           let(:params){{ :syslog => true }}

--- a/spec/classes/ntpd_spec.rb
+++ b/spec/classes/ntpd_spec.rb
@@ -7,6 +7,14 @@ describe 'simp_options' do
       context "on #{os}" do
         let(:facts){ facts }
 
+        context 'default parameters for simp_options::ntpd' do
+          let(:hieradata) { 'simp_options'}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('simp_options::ntpd').with(
+            :servers => []
+          ) }
+        end
+
         context 'invalid ntpd servers' do
           let(:hieradata) { 'simp_options_with_invalid_ntpd_servers'}
           it { is_expected.not_to compile.with_all_deps }

--- a/spec/classes/puppet_spec.rb
+++ b/spec/classes/puppet_spec.rb
@@ -7,6 +7,14 @@ describe 'simp_options' do
       context "on #{os}" do
         let(:facts){ facts }
 
+        context 'default parameters for simp_options::puppet' do
+          let(:hieradata) { 'simp_options'}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('simp_options::puppet').with(
+            :ca_port => 8141
+          ) }
+        end
+
         context 'invalid simp_options::puppet::server' do
           let(:hieradata) { 'simp_options_with_invalid_puppet_server'}
           it { is_expected.not_to compile.with_all_deps}

--- a/spec/classes/rsync_spec.rb
+++ b/spec/classes/rsync_spec.rb
@@ -8,6 +8,15 @@ describe 'simp_options' do
       context "on #{os}" do
         let(:facts){ facts }
 
+        context 'default parameters for simp_options::rsync' do
+          let(:hieradata) { 'simp_options'}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('simp_options::rsync').with(
+            :server => '127.0.0.1',
+            :timeout => 1
+          ) }
+        end
+
         context 'invalid simp_options::rsync::server' do
           let(:hieradata) { 'simp_options_with_invalid_rsync_server'}
           it { is_expected.not_to compile.with_all_deps}

--- a/spec/classes/syslog_spec.rb
+++ b/spec/classes/syslog_spec.rb
@@ -7,6 +7,16 @@ describe 'simp_options' do
       context "on #{os}" do
         let(:facts){ facts }
 
+        context 'default parameters for simp_options::syslog' do
+          let(:hieradata) { 'simp_options'}
+          let(:params){{ :syslog => true }}
+          it { is_expected.to compile.with_all_deps }
+          it { is_expected.to contain_class('simp_options::syslog').with(
+            :log_servers => [],
+            :failover_log_servers => []
+          ) }
+        end
+
         context 'invalid simp_options::syslog::log_servers' do
           let(:hieradata) { 'simp_options_with_invalid_syslog_log_servers'}
           it { is_expected.not_to compile.with_all_deps}

--- a/spec/fixtures/hieradata/simp_options_with_invalid_ldap_master.yaml
+++ b/spec/fixtures/hieradata/simp_options_with_invalid_ldap_master.yaml
@@ -8,5 +8,5 @@ simp_options::ldap::bind_hash : '{SSHA}DEADBEEFdeadbeefDEADBEEFdeadbeef'
 simp_options::ldap::sync_pw : 'N0t=@=R#@l=Sync=P@ssw0rd'
 simp_options::ldap::sync_hash : '{SSHA}DeadBeerDeadBeefDeadBeefDeadBeef'
 simp_options::ldap::root_hash : '{SSHA}deadbeefDEADBEEFdeadbeefDEADBEEF'
-simp_options::ldap::master : '1.2.3.400'
+simp_options::ldap::master : '1.2.3.4'
 

--- a/spec/fixtures/hieradata/simp_options_with_invalid_ldap_uri.yaml
+++ b/spec/fixtures/hieradata/simp_options_with_invalid_ldap_uri.yaml
@@ -9,4 +9,4 @@ simp_options::ldap::sync_pw : 'N0t=@=R#@l=Sync=P@ssw0rd'
 simp_options::ldap::sync_hash : '{SSHA}DeadBeerDeadBeefDeadBeefDeadBeef'
 simp_options::ldap::root_hash : '{SSHA}deadbeefDEADBEEFdeadbeefDEADBEEF'
 simp_options::ldap::uri :
- - '1.2.3.500'
+ - '1.2.3.5'

--- a/spec/fixtures/hieradata/simp_options_with_pki_simp.yaml
+++ b/spec/fixtures/hieradata/simp_options_with_pki_simp.yaml
@@ -1,0 +1,4 @@
+---
+simp_options::puppet::server : 'puppet.example.com'
+simp_options::puppet::ca : 'puppet.example.com'
+simp_options::pki : 'simp'

--- a/spec/fixtures/hieradata/simp_options_with_pki_true.yaml
+++ b/spec/fixtures/hieradata/simp_options_with_pki_true.yaml
@@ -1,0 +1,4 @@
+---
+simp_options::puppet::server : 'puppet.example.com'
+simp_options::puppet::ca : 'puppet.example.com'
+simp_options::pki : true


### PR DESCRIPTION
Now that we have commited to strong typing for SIMP6, revert
back to an Integer type for simp_options::rsync::timeout and
use appropriate simplib types for other parameters.

SIMP-2416 #close