### PR TITLE
(SIMP-2472) Updated default pki::source

### DIFF
--- a/manifests/pki.pp
+++ b/manifests/pki.pp
@@ -9,7 +9,7 @@
 # @author SIMP Team - https://simp-project.com
 #
 class simp_options::pki (
-  Stdlib::Absolutepath $source = '/etc/pki/simp'
+  Stdlib::Absolutepath $source = '/etc/pki/simp/x509'
 ){
   assert_private()
 }


### PR DESCRIPTION
- Certs now reside in /etc/pki/simp/x509

SIMP-2472 #comment Done in simp_options