### PR TITLE
(SIMP-2505) Postfix failing because IPV6 not disable properly

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -78,6 +78,7 @@ class simp_options (
   Boolean                       $firewall     = false,
   Boolean                       $haveged      = false,
   Boolean                       $ipsec        = false,
+  Boolean                       $ipv6         = false,
   Boolean                       $kerberos     = false,
   Boolean                       $ldap         = false,
   Boolean                       $logrotate    = false,


### PR DESCRIPTION
  - simp uses simp_options::ipv6 but it does not exist.

SIMP-2505 #comment this does not fix the problem but needs doing