### PR TITLE
(SIMP-3035) Add 'simp_options::package_ensure'.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Wed Apr 12 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 1.0.2-0
+- Add simp_options::package_ensure
+
 * Tue Feb 07 2017 Liz Nemsick <lnemsick.simp@gmail.com> - 1.0.1-0
 - Removed simp_options::ldap::root_hash as this is not a global catalyst
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,27 +68,32 @@
 #
 #   If you need this to be more (or less) restrictive for a given class, you
 #   can override it for the specific class via that class' parameters.
+# @param package_ensure The default ensure parmeter for packages.
+#
+#   Can be either 'latest' or 'installed'; currently defaults to 'latest' for
+#   historical reasons. Default may change in a newer version.
 #
 # @author SIMP Team - https://simp-project.com
 #
 class simp_options (
-  Boolean                       $auditd       = false,
-  Boolean                       $clamav       = false,
-  Boolean                       $fips         = false,
-  Boolean                       $firewall     = false,
-  Boolean                       $haveged      = false,
-  Boolean                       $ipsec        = false,
-  Boolean                       $kerberos     = false,
-  Boolean                       $ldap         = false,
-  Boolean                       $logrotate    = false,
-  Boolean                       $pam          = false,
-  Variant[Boolean,Enum['simp']] $pki          = false,
-  Boolean                       $selinux      = false,
-  Boolean                       $sssd         = false,
-  Boolean                       $stunnel      = false,
-  Boolean                       $syslog       = false,
-  Boolean                       $tcpwrappers  = false,
-  Simplib::Netlist              $trusted_nets = ['127.0.0.1', '::1']
+  Boolean                       $auditd         = false,
+  Boolean                       $clamav         = false,
+  Boolean                       $fips           = false,
+  Boolean                       $firewall       = false,
+  Boolean                       $haveged        = false,
+  Boolean                       $ipsec          = false,
+  Boolean                       $kerberos       = false,
+  Boolean                       $ldap           = false,
+  Boolean                       $logrotate      = false,
+  Boolean                       $pam            = false,
+  Variant[Boolean,Enum['simp']] $pki            = false,
+  Boolean                       $selinux        = false,
+  Boolean                       $sssd           = false,
+  Boolean                       $stunnel        = false,
+  Boolean                       $syslog         = false,
+  Boolean                       $tcpwrappers    = false,
+  Simplib::Netlist              $trusted_nets   = ['127.0.0.1', '::1'],
+  String                        $package_ensure = 'latest'
 ){
   validate_net_list($trusted_nets)
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_options",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "SIMP Team",
   "summary": "Variables enabling SIMP core capabilities",
   "license": "Apache-2.0",
@@ -40,10 +40,6 @@
     {
       "name": "puppet",
       "version_requirement": ">= 4.7.0"
-    },
-    {
-      "name": "pe",
-      "version_requirement": ">= 2016.4.0"
     }
   ],
   "data_provider": "hiera"

--- a/spec/classes/ldap_spec.rb
+++ b/spec/classes/ldap_spec.rb
@@ -13,14 +13,14 @@ describe 'simp_options' do
           # make sure interpolation of hieradata in modules's data/ is working
           it {
             is_expected.to contain_class('simp_options::ldap').with(
-              :base_dn   => 'dc=example,dc=com',
-              :bind_dn   => 'cn=hostAuth,ou=Hosts,dc=example,dc=com',
+              :base_dn   => 'DC=example,DC=com',
+              :bind_dn   => 'cn=hostAuth,ou=Hosts,DC=example,DC=com',
               :bind_pw   => 'N0t=@=R#@l=B1nd=P@ssw0rd',
               :bind_hash => '{SSHA}DEADBEEFdeadbeefDEADBEEFdeadbeef',
-              :sync_dn   => 'cn=LDAPSync,ou=Hosts,dc=example,dc=com',
+              :sync_dn   => 'cn=LDAPSync,ou=Hosts,DC=example,DC=com',
               :sync_pw   => 'N0t=@=R#@l=Sync=P@ssw0rd',
               :sync_hash => '{SSHA}DeadBeerDeadBeefDeadBeefDeadBeef',
-              :root_dn   => 'cn=LDAPAdmin,ou=People,dc=example,dc=com',
+              :root_dn   => 'cn=LDAPAdmin,ou=People,DC=example,DC=com',
               :master    => 'ldap://puppet.example.com',
               :uri       => ['ldap://puppet.example.com']
             )


### PR DESCRIPTION
Add a catalyst that can change the simp modules default package ensure
from 'latest' (the current 6.x api) to 'installed'.

SIMP-3035 #close