### PR TITLE
(SIMP-2784) Add simp_options::libkv

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Sat Apr 15 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 1.0.3-0
+- Add simp_options::libkv
+
 * Wed Apr 12 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 1.0.2-0
 - Add simp_options::package_ensure
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,6 +73,10 @@
 #   Can be either 'latest' or 'installed'; currently defaults to 'latest' for
 #   historical reasons. Default may change in a newer version.
 #
+# @param libkv Feature flag for libkv.
+#
+#   If set to true, it will enable the libkv backend for some functions.
+#
 # @author SIMP Team - https://simp-project.com
 #
 class simp_options (
@@ -93,7 +97,8 @@ class simp_options (
   Boolean                       $syslog         = false,
   Boolean                       $tcpwrappers    = false,
   Simplib::Netlist              $trusted_nets   = ['127.0.0.1', '::1'],
-  String                        $package_ensure = 'latest'
+  String                        $package_ensure = 'latest',
+  Boolean                       $libkv          = false,
 ){
   validate_net_list($trusted_nets)
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_options",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "author": "SIMP Team",
   "summary": "Variables enabling SIMP core capabilities",
   "license": "Apache-2.0",


### PR DESCRIPTION
* Add a simp_option to toggle the libkv codepath in certain functions.
  This will allow us to push libkv and changes to the underlying
  functions in a suceeding 6 release, and default to on in 7

SIMP-2784 #close