### PR TITLE
(SIMP-3993) Fix issues with puppet and ldap class

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Nov 03 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.4-0
+- Fix parameter issues in simp_options::ldap
+- Fix PE support in simp_options::puppet
+
 * Sat Apr 15 2017 Dylan Cochran <dylan.cochran@onyxpoint.com> - 1.0.3-0
 - Add simp_options::libkv
 - Update puppet requirement in metadata.json

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,4 +1,0 @@
-Requires: pupmod-puppetlabs-stdlib < 5.0.0-0
-Requires: pupmod-puppetlabs-stdlib >= 4.9.0-0
-Requires: pupmod-simp-simplib < 4.0.0-0
-Requires: pupmod-simp-simplib >= 3.1.0-0

--- a/manifests/ldap.pp
+++ b/manifests/ldap.pp
@@ -34,9 +34,9 @@ class simp_options::ldap (
   String              $sync_pw,
   String              $sync_hash,
   String              $base_dn    = simplib::ldap::domain_to_dn(),
-  String              $bind_dn    = "cn=hostAuth,ou=Hosts,${simp_options::ldap::base_dn}",
-  String              $sync_dn    = "cn=LDAPSync,ou=Hosts,${simp_options::ldap::base_dn}",
-  String              $root_dn    = "cn=LDAPAdmin,ou=People,${simp_options::ldap::base_dn}",
+  String              $bind_dn    = "cn=hostAuth,ou=Hosts,${base_dn}",
+  String              $sync_dn    = "cn=LDAPSync,ou=Hosts,${base_dn}",
+  String              $root_dn    = "cn=LDAPAdmin,ou=People,${base_dn}",
   Simplib::URI        $master     = "ldap://${simp_options::puppet::server}",
   Array[Simplib::URI] $uri        = ["ldap://${simp_options::puppet::server}"]
 ){

--- a/manifests/puppet.pp
+++ b/manifests/puppet.pp
@@ -16,7 +16,7 @@
 class simp_options::puppet (
   Simplib::Host $server,
   Simplib::Host $ca,
-  Simplib::Serverdistribution $server_distribution = fact('pe_build') ? { Undef => 'PC1', default => 'PE' },
+  Simplib::Serverdistribution $server_distribution = $facts['is_pe'] ? { true => 'PE', default => 'PC1' },
   Simplib::Port $ca_port = $server_distribution ? { 'PE' => 8140, default => 8141 }
 ){
   assert_private()

--- a/manifests/puppet.pp
+++ b/manifests/puppet.pp
@@ -16,8 +16,8 @@
 class simp_options::puppet (
   Simplib::Host $server,
   Simplib::Host $ca,
-  Simplib::Port $ca_port = 8141,
-  Simplib::Serverdistribution $server_distribution = 'PC1'
+  Simplib::Serverdistribution $server_distribution = fact('pe_build') ? { Undef => 'PC1', default => 'PE' },
+  Simplib::Port $ca_port = $server_distribution ? { 'PE' => 8140, default => 8141 }
 ){
   assert_private()
   validate_net_list($server)

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_options",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "author": "SIMP Team",
   "summary": "Variables enabling SIMP core capabilities",
   "license": "Apache-2.0",


### PR DESCRIPTION
* simp_options::ldap parameter references did not work in Puppet 5
* simp_options::puppet parameters did not auto-adjust for Puppet
Enterprise

SIMP-3993 #comment fix simp_options::ldap and simp_options::puppet