### PR TITLE
(SIMP-3892) Add UID and GID catalysts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,97 +1,97 @@
 #
 ---
-puppet-syntax: 
+puppet-syntax:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.1
-  script: 
+  script:
     - bundle install
     - bundle exec rake syntax
-puppet-lint: 
+puppet-lint:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.1
-  script: 
+  script:
     - bundle install
     - bundle exec rake lint
-puppet-metadata: 
+puppet-metadata:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.1
-  script: 
+  script:
     - bundle install
     - bundle exec rake metadata
 unit-test-ruby-2.1:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.1
-  script: 
+  script:
     - bundle install
     - bundle exec rake spec
 unit-test-ruby-2.2:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.2
   allow_failure: true
-  script: 
+  script:
     - bundle install
     - bundle exec rake spec
 unit-test-ruby-2.3:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.3
   allow_failure: true
-  script: 
+  script:
     - bundle install
     - bundle exec rake spec
 
 # For PE LTS Support
 # See: https://puppet.com/misc/puppet-enterprise-lifecycle
-puppet4.7-syntax: 
+puppet4.7-syntax:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.1
-  script: 
+  script:
     - PUPPET_VERSION=4.7 bundle install
     - PUPPET_VERSION=4.7 bundle exec rake syntax
 unit-test-puppet4.7-ruby-2.1:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.1
-  script: 
+  script:
     - PUPPET_VERSION=4.7 bundle install
     - PUPPET_VERSION=4.7 bundle exec rake spec
 unit-test-puppet4.7-ruby-2.2:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.2
   allow_failure: true
-  script: 
+  script:
     - PUPPET_VERSION=4.7 bundle install
     - PUPPET_VERSION=4.7 bundle exec rake spec
 unit-test-puppet4.7-ruby-2.3:
   stage: test
-  tags: 
+  tags:
     - docker
   image: ruby:2.3
   allow_failure: true
-  script: 
+  script:
     - PUPPET_VERSION=4.7 bundle install
     - PUPPET_VERSION=4.7 bundle exec rake spec
 
-acceptance-test: 
+acceptance-test:
   stage: test
-  tags: 
+  tags:
     - beaker
-  script: 
+  script:
     - bundle install --no-binstubs --path=vendor
-    - bundle exec rake acceptance
+    - bundle exec rake beaker:suites

--- a/.puppet-lint.rc
+++ b/.puppet-lint.rc
@@ -2,7 +2,7 @@
 --relative
 --no-class_inherits_from_params_class-check
 --no-140chars-check
---no-empty_string-check
+--no-empty_string_assignment-check
 --no-trailing_comma-check
 # This is here because the code can't handle lookups in parameters and we have
 # a LOT of those

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,48 +8,81 @@
 # PE 2017.2   4.10  2.1.9  TBD
 ---
 language: ruby
-sudo: false
 cache: bundler
-before_script:
-  - bundle update
+sudo: false
+
 bundler_args: --without development system_tests --path .vendor
-before_install: rm Gemfile.lock || true
-script:
-  - bundle exec rake test
+
 notifications:
   email: false
-rvm:
-  - 2.1.9
-env:
-  global:
-    - STRICT_VARIABLES=yes
-  matrix:
-    - PUPPET_VERSION="~> 4.8.2" FORGE_PUBLISH=true
-    - PUPPET_VERSION="~> 4.10.0"
-    - PUPPET_VERSION="~> 4.9.2"
-    - PUPPET_VERSION="~> 4.7.0"
-matrix:
-  fast_finish: true
 
-before_deploy:
-  - 'bundle exec rake metadata_lint'
-  - 'bundle exec rake clobber'
-  - 'bundle exec rake spec_clean'
-  - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
-  - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
-deploy:
-  - provider: puppetforge
-    user: simp
-    password:
-        secure: "tNeONexWRLmHJl4s1VwvAYLWFZ/xbqgSdlIXGB9W3cgQOQYf5d4RexLqmG3JnSPvyIvWLRfXXfbibr5GZ4OKPl1y/Jqc4lZRhgxjS67GJUJMTm2ISd3gwt5hgPAhsPmqLz1Hh/+zTdXIUC2LQupnSmbGXt3KpOMTQ6iBcoYBW0OcRwEwiigui4DO+ZcleewB7JrWz4aDzx0Vitz+ySZ5qDeVTDqf/SotJKKeeGrZrs53uUKSnjmVoo9QpD27IhOrRolNKFuvZPCq5a0GCMP1pZELWoCvNTLgLbmKr3S9lR9WxB/NEQKvvR6gkGWI7RKLv4HHQXGQGHdxxNyDMWbELIaiLmrwRVOGUKHM46h5zs5qi0Tei6rrh0doUV/0Golqk6Ki2Ggbtm4FqmpmRk/yzaCkpgEMGaV5TeYQKIYSUhkYXHjI3YKJQ4XgK9C6bDV49Zj811uqguEqoUqQyG5ZshEBPTm39z1WGyJtd2FwqYSgUgInXS52I1Sp0QqTMZaeJ5RpDw15pO/tygPv4QBbVi29XMAOsxEXL7bBUUYxm+fd+c/Vb3Ey3m/tOCXoSUc4ATME4xXc82tTEKjyg7Di84xbsW+Oz+gkT2i9mM2xqd1oRL9C6Ok212vDDTMgJUWrWbgVRrQhAcsHCIPIUcPlG3ubv33bXQGeSv/x+JGu+LY="
-    on:
-      tags: true
+addons:
+  apt:
+    packages:
+      - rpm
+
+before_install:
+  - rm -f Gemfile.lock
+
+jobs:
+  include:
+    - stage: spec
+      rvm: 2.4.1
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5"
+      script:
+        - bundle exec rake check:dot_underscore
+        - bundle exec rake check:test_file
+        - bundle exec rake pkg:check_version
+        - bundle exec rake metadata_lint
+        - bundle exec rake compare_latest_tag
+        - bundle exec rake lint
+        - bundle exec puppet module build
+
+    - stage: spec
+      rvm: 2.4.1
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 5.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
       rvm: 2.1.9
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
-  - provider: releases
-    api_key:
-        secure: "OvcW4ZBDXv4S20QyLnf4Z1jzrmgGqPgUzDPt7Rl9oZWN51xOOqyq50rXY6Ia5whPtWqSdjdCsOuT9yQKJgV39Q7/caAhFMvPuNqvulz3gNuEnWbPQfsKyhQuM3oDX333QUBK6vzqp7TI2NO1KTPqaZ7GMKYs+QXcfZ91/TF/sQ25nQU723WLxQn2AbsmmbeWMY/j1PE+YUS88MyWVcgWec2YT8JsWjtkmgTEsqcA5sIc4wlccp9rz61Zd6FiJ+NTyRO+ZQ1BcqzlApJwXRyBKbEOnjx6AHP4pT6x4HobdDqOgdjFG2Y/kTrwicZxDafLH+jO7qsjSM/cCjhlSOEawn4ur0RT89zKmt1YzZ1beI19VtDjZsX8vrZEaRyxL3EkPQYsNL7RlL5SEja0Z4z77qdTS7vPMnmQg3/EUlO2FDaDC52v0Cl1g8CMd2CuVOvGr8kAF3jtfJvsecXpvEoPykZfYcis2SMQjQDO0KnOlerUmwlKzUsakSFlJqyVk3ddub0eb2bPcHu8t9LG0qQga2zk1caCzdkEGAzXgZILIpO6VRPrhaDWMs+Q2zuXih1bw878mSOz42Ci3Ony7jst0JrKBk+1AMdYL8sD1P1xjx1L7AXiituwvuVDTjQdw17kYUF4pY035ES20PeiDdMkVxL9F/pgAg5882gHmae8tAU="
-    skip_cleanup: true
-    on:
-      tags: true
-      condition: '($SKIP_FORGE_PUBLISH != true) && ($FORGE_PUBLISH = true)'
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.10.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.9.2"
+      script:
+        - bundle exec rake spec
+
+    - stage: spec
+      rvm: 2.1.9
+      env: STRICT_VARIABLES=yes TRUSTED_NODE_DATA=yes PUPPET_VERSION="~> 4.7.0"
+      script:
+        - bundle exec rake spec
+
+    - stage: deploy
+      rvm: 2.4.1
+      script:
+        - true
+      before_deploy:
+        - "export PUPMOD_METADATA_VERSION=`ruby -r json -e \"puts JSON.parse(File.read('metadata.json')).fetch('version')\"`"
+        - '[[ $TRAVIS_TAG =~ ^simp-${PUPMOD_METADATA_VERSION}$|^${PUPMOD_METADATA_VERSION}$ ]]'
+
+      deploy:
+        - provider: releases
+          api_key:
+            secure: "OvcW4ZBDXv4S20QyLnf4Z1jzrmgGqPgUzDPt7Rl9oZWN51xOOqyq50rXY6Ia5whPtWqSdjdCsOuT9yQKJgV39Q7/caAhFMvPuNqvulz3gNuEnWbPQfsKyhQuM3oDX333QUBK6vzqp7TI2NO1KTPqaZ7GMKYs+QXcfZ91/TF/sQ25nQU723WLxQn2AbsmmbeWMY/j1PE+YUS88MyWVcgWec2YT8JsWjtkmgTEsqcA5sIc4wlccp9rz61Zd6FiJ+NTyRO+ZQ1BcqzlApJwXRyBKbEOnjx6AHP4pT6x4HobdDqOgdjFG2Y/kTrwicZxDafLH+jO7qsjSM/cCjhlSOEawn4ur0RT89zKmt1YzZ1beI19VtDjZsX8vrZEaRyxL3EkPQYsNL7RlL5SEja0Z4z77qdTS7vPMnmQg3/EUlO2FDaDC52v0Cl1g8CMd2CuVOvGr8kAF3jtfJvsecXpvEoPykZfYcis2SMQjQDO0KnOlerUmwlKzUsakSFlJqyVk3ddub0eb2bPcHu8t9LG0qQga2zk1caCzdkEGAzXgZILIpO6VRPrhaDWMs+Q2zuXih1bw878mSOz42Ci3Ony7jst0JrKBk+1AMdYL8sD1P1xjx1L7AXiituwvuVDTjQdw17kYUF4pY035ES20PeiDdMkVxL9F/pgAg5882gHmae8tAU="
+          skip_cleanup: true
+          on:
+            tags: true
+            condition: '($SKIP_FORGE_PUBLISH != true)'
+        - provider: puppetforge
+          user: simp
+          password:
+            secure: "tNeONexWRLmHJl4s1VwvAYLWFZ/xbqgSdlIXGB9W3cgQOQYf5d4RexLqmG3JnSPvyIvWLRfXXfbibr5GZ4OKPl1y/Jqc4lZRhgxjS67GJUJMTm2ISd3gwt5hgPAhsPmqLz1Hh/+zTdXIUC2LQupnSmbGXt3KpOMTQ6iBcoYBW0OcRwEwiigui4DO+ZcleewB7JrWz4aDzx0Vitz+ySZ5qDeVTDqf/SotJKKeeGrZrs53uUKSnjmVoo9QpD27IhOrRolNKFuvZPCq5a0GCMP1pZELWoCvNTLgLbmKr3S9lR9WxB/NEQKvvR6gkGWI7RKLv4HHQXGQGHdxxNyDMWbELIaiLmrwRVOGUKHM46h5zs5qi0Tei6rrh0doUV/0Golqk6Ki2Ggbtm4FqmpmRk/yzaCkpgEMGaV5TeYQKIYSUhkYXHjI3YKJQ4XgK9C6bDV49Zj811uqguEqoUqQyG5ZshEBPTm39z1WGyJtd2FwqYSgUgInXS52I1Sp0QqTMZaeJ5RpDw15pO/tygPv4QBbVi29XMAOsxEXL7bBUUYxm+fd+c/Vb3Ey3m/tOCXoSUc4ATME4xXc82tTEKjyg7Di84xbsW+Oz+gkT2i9mM2xqd1oRL9C6Ok212vDDTMgJUWrWbgVRrQhAcsHCIPIUcPlG3ubv33bXQGeSv/x+JGu+LY="
+          on:
+            tags: true
+            rvm: 2.4.1
+            condition: '($SKIP_FORGE_PUBLISH != true)'

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Wed Dec 13 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.1.0-0
+- Added simp_options::uid and simp_options::gid classes for ID limit
+  consistency across the entire infrastructure
+
 * Fri Nov 03 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.0.4-0
 - Fix parameter issues in simp_options::ldap
 - Fix PE support in simp_options::puppet

--- a/manifests/gid.pp
+++ b/manifests/gid.pp
@@ -13,7 +13,7 @@
 # @author SIMP Team - https://simp-project.com
 #
 class simp_options::gid (
-  Integer[0]           $min = 1000,
+  Integer[0]           $min = pick(to_integer($facts['uid_min']), 1000),
   Optional[Integer[1]] $max = undef
 ){
   assert_private()

--- a/manifests/gid.pp
+++ b/manifests/gid.pp
@@ -1,0 +1,20 @@
+#
+# Provides system-wide defaults for GID settings
+#
+# @param min
+#   The lowest allowed regular user GID for the system
+#
+# @param max
+#   The highest allowed regular user GID for the system
+#
+#   * If not defined, applications should simply do what makes sense for them
+#     internally
+#
+# @author SIMP Team - https://simp-project.com
+#
+class simp_options::gid (
+  Integer[0]           $min = 1000,
+  Optional[Integer[1]] $max = undef
+){
+  assert_private()
+}

--- a/manifests/gid.pp
+++ b/manifests/gid.pp
@@ -13,8 +13,8 @@
 # @author SIMP Team - https://simp-project.com
 #
 class simp_options::gid (
-  Integer[0]           $min = pick(to_integer($facts['uid_min']), 1000),
-  Optional[Integer[1]] $max = undef
+  Integer[0]           $min = pick(fact('login_defs.gid_min'), 1000),
+  Optional[Integer[1]] $max = fact('login_defs.gid_max')
 ){
   assert_private()
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -107,6 +107,8 @@ class simp_options (
   include '::simp_options::openssl'
   include '::simp_options::puppet'
   include '::simp_options::rsync'
+  include '::simp_options::uid'
+  include '::simp_options::gid'
 
   if $ldap {
     include '::simp_options::ldap'

--- a/manifests/uid.pp
+++ b/manifests/uid.pp
@@ -13,7 +13,7 @@
 # @author SIMP Team - https://simp-project.com
 #
 class simp_options::uid (
-  Integer[0]           $min = 1000,
+  Integer[0]           $min = pick(to_integer($facts['uid_min']), 1000),
   Optional[Integer[1]] $max = undef
 ){
   assert_private()

--- a/manifests/uid.pp
+++ b/manifests/uid.pp
@@ -1,0 +1,20 @@
+#
+# Provides system-wide defaults for UID settings
+#
+# @param min
+#   The lowest allowed regular user UID for the system
+#
+# @param max
+#   The highest allowed regular user UID for the system
+#
+#   * If not defined, applications should simply do what makes sense for them
+#     internally
+#
+# @author SIMP Team - https://simp-project.com
+#
+class simp_options::uid (
+  Integer[0]           $min = 1000,
+  Optional[Integer[1]] $max = undef
+){
+  assert_private()
+}

--- a/manifests/uid.pp
+++ b/manifests/uid.pp
@@ -13,8 +13,8 @@
 # @author SIMP Team - https://simp-project.com
 #
 class simp_options::uid (
-  Integer[0]           $min = pick(to_integer($facts['uid_min']), 1000),
-  Optional[Integer[1]] $max = undef
+  Integer[0]           $min = pick(fact('login_defs.uid_min'), 1000),
+  Optional[Integer[1]] $max = fact('login_defs.uid_max')
 ){
   assert_private()
 }

--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 3.1.0 < 4.0.0"
+      "version_requirement": ">= 3.10.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_options",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "author": "SIMP Team",
   "summary": "Variables enabling SIMP core capabilities",
   "license": "Apache-2.0",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -7,6 +7,8 @@ shared_examples_for  'a simp_options class' do
   it { is_expected.to contain_class('simp_options::openssl') }
   it { is_expected.to contain_class('simp_options::puppet') }
   it { is_expected.to contain_class('simp_options::rsync') }
+  it { is_expected.to contain_class('simp_options::uid') }
+  it { is_expected.to contain_class('simp_options::gid') }
 end
 
 describe 'simp_options' do


### PR DESCRIPTION
The `pam`, `sssd`, and `useradd` modules all presently require
consistent settings for MIN and MAX UID and GID values but have no
single source of truth.

Classes have been added to remedy this situation.

SIMP-3892 #comment Added global catalysts for UID and GID