### PR TITLE
(SIMP-3858) Remove simp_options::selinux

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Mon Apr 23 2018 Jeanne Greulich <jeanne.greulich@onyxpoint.com> - 1.2.0-0
+- Removed simp_options::selinux.  Conflicts between this setting
+  and what was in the scenario class lists was causing unexpected results.
+
 * Wed Dec 13 2017 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.1.0-0
 - Added simp_options::uid and simp_options::gid classes for ID limit
   consistency across the entire infrastructure

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,10 +48,6 @@
 #   If true,  don't include SIMP's ``::pki`` class, but use ``::pki::copy``.
 #   If 'simp', include SIMP's ``::pki`` class, and use ``::pki::copy``.
 #
-# @param selinux Whether to include SIMP's ``::selinux`` class (which
-#   effectively manages the ``SELinux`` enforcement and mode) and manage
-#   SIMP-specific ``SELinux`` configurations
-#
 # @param sssd Whether to use ``SSSD``
 #
 # @param stunnel Whether to include SIMP's ``::stunnel`` class and use it to
@@ -91,7 +87,6 @@ class simp_options (
   Boolean                       $logrotate      = false,
   Boolean                       $pam            = false,
   Variant[Boolean,Enum['simp']] $pki            = false,
-  Boolean                       $selinux        = false,
   Boolean                       $sssd           = false,
   Boolean                       $stunnel        = false,
   Boolean                       $syslog         = false,

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_options",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": "SIMP Team",
   "summary": "Variables enabling SIMP core capabilities",
   "license": "Apache-2.0",


### PR DESCRIPTION
  - removed selinux option.  Instead rely on scenario class lists
    for including selinux module.

SIMP-3858 #comment updated simp_optins
SIMP-4526 #close