### PR TITLE
(SIMP-6229) Update upper bound stdlib < 6.0.0

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,8 +2,6 @@
 fixtures:
   repositories:
     simplib: https://github.com/simp/pupmod-simp-simplib
-    stdlib:
-      repo: https://github.com/simp/puppetlabs-stdlib
-      branch: master
+    stdlib: https://github.com/simp/puppetlabs-stdlib
   symlinks:
     simp_options: "#{source_dir}"

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 1.2.2-0
+- Update the upper bound of stdlib to < 6.0.0
+- Update a URL in the README.md
+
 * Wed Nov 07 2018 Liz Nemsick <lnemsick.simp@gmail.com> - 1.2.1-0
 - Update badges and contribution guide URL in README.md
 

--- a/README.md
+++ b/README.md
@@ -78,4 +78,4 @@ This module is applicable to SIMP systems or systems containing SIMP components.
 
 ## Development
 
-Please read our [Contribution Guide](http://simp-doc.readthedocs.io/en/stable/contributors_guide/index.html).
+Please read our [Contribution Guide](https://simp.readthedocs.io/en/stable/contributors_guide/index.html).

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_options",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "author": "SIMP Team",
   "summary": "Variables enabling SIMP core capabilities",
   "license": "Apache-2.0",
@@ -13,7 +13,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.9.0 < 5.0.0"
+      "version_requirement": ">= 4.9.0 < 6.0.0"
     },
     {
       "name": "simp/simplib",


### PR DESCRIPTION
- Update the upper bound of stdlib to < 6.0.0
- Update a URL in the README.md

SIMP-6229 #comment pupmod-simp-simp_options