### PR TITLE
(SIMP-6119) Use namespaced simplib::validate_uri_list

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+* Tue Mar 19 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 1.2.3-0
+- Use simplib::validate_net_list in lieu of deprecated Puppet 3
+  validate_net_list
+- Use simplib::validate_uri_list in lieu of deprecated Puppet 3
+  validate_uri_list
+
 * Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 1.2.2-0
 - Update the upper bound of stdlib to < 6.0.0
 - Update a URL in the README.md

--- a/manifests/dns.pp
+++ b/manifests/dns.pp
@@ -27,5 +27,5 @@ class simp_options::dns (
   Array[Simplib::Host] $servers = []
 ){
   assert_private()
-  validate_net_list($servers)
+  simplib::validate_net_list($servers)
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -96,7 +96,7 @@ class simp_options (
   String                        $package_ensure = 'latest',
   Boolean                       $libkv          = false,
 ){
-  validate_net_list($trusted_nets)
+  simplib::validate_net_list($trusted_nets)
 
   include 'simp_options::dns'
   include 'simp_options::ntpd'

--- a/manifests/ldap.pp
+++ b/manifests/ldap.pp
@@ -41,6 +41,6 @@ class simp_options::ldap (
   Array[Simplib::URI] $uri        = ["ldap://${simp_options::puppet::server}"]
 ){
   assert_private()
-  validate_uri_list($master,['ldap','ldaps'])
-  validate_uri_list($uri,['ldap','ldaps'])
+  simplib::validate_uri_list($master,['ldap','ldaps'])
+  simplib::validate_uri_list($uri,['ldap','ldaps'])
 }

--- a/manifests/ntpd.pp
+++ b/manifests/ntpd.pp
@@ -14,5 +14,5 @@ class simp_options::ntpd (
   Array[Simplib::Host] $servers = []
 ){
   assert_private()
-  validate_net_list($servers)
+  simplib::validate_net_list($servers)
 }

--- a/manifests/puppet.pp
+++ b/manifests/puppet.pp
@@ -20,6 +20,6 @@ class simp_options::puppet (
   Simplib::Port $ca_port = $server_distribution ? { 'PE' => 8140, default => 8141 }
 ){
   assert_private()
-  validate_net_list($server)
-  validate_net_list($ca)
+  simplib::validate_net_list($server)
+  simplib::validate_net_list($ca)
 }

--- a/manifests/rsync.pp
+++ b/manifests/rsync.pp
@@ -19,5 +19,5 @@ class simp_options::rsync (
   Integer       $timeout = 1
 ){
   assert_private()
-  validate_net_list($server)
+  simplib::validate_net_list($server)
 }

--- a/manifests/syslog.pp
+++ b/manifests/syslog.pp
@@ -14,6 +14,6 @@ class simp_options::syslog (
   Array[Simplib::Host] $failover_log_servers = []
 ){
   assert_private()
-  validate_net_list($log_servers)
-  validate_net_list($failover_log_servers)
+  simplib::validate_net_list($log_servers)
+  simplib::validate_net_list($failover_log_servers)
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_options",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "author": "SIMP Team",
   "summary": "Variables enabling SIMP core capabilities",
   "license": "Apache-2.0",


### PR DESCRIPTION
- Use simplib::validate_uri_list in lieu of deprecated Puppet 3
  validate_uri_list
- Use simplib::validate_net_list in lieu of deprecated Puppet 3
  validate_net_list

SIMP-6119 #close