### PR TITLE
(SIMP 7113) Remove clamav from simp class lists.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,7 +1,10 @@
 * Tue Oct 29 2019 Jeanne Greulich <jeannegreulich@onyxpoint.com> - 1.4.0-0
-- Mark the clamav catalyst as deprecated. As of SIMP 6.5 clamav is no
+- This change marks the clamav catalyst as deprecated. As of SIMP 6.5 clamav is no
   longer included in the class list of the simp scenarios so this
   catalyst is not needed to disable it.
+  To have simp manage ``ClamAV`` on your systems the ``clamav`` class must
+  be added to your systems class list.
+  See the simp ``clamav`` module README for information on managing ``ClamAV``.
 
 * Tue Sep 03 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.4.0-0
 - The following are now optional:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,10 +1,10 @@
 * Tue Oct 29 2019 Jeanne Greulich <jeannegreulich@onyxpoint.com> - 1.4.0-0
-- This change marks the clamav catalyst as deprecated. As of SIMP 6.5 clamav is no
-  longer included in the class list of the simp scenarios so this
-  catalyst is not needed to disable it.
-  To have simp manage ``ClamAV`` on your systems the ``clamav`` class must
-  be added to your systems class list.
-  See the simp ``clamav`` module README for information on managing ``ClamAV``.
+- This change marks the clamav catalyst as deprecated.
+  * As of SIMP 6.5, SIMP's ``clamav`` class is no longer included in the class
+    list of the SIMP scenarios. So, this catalyst is not needed to disable it.
+  * To have SIMP manage ``ClamAV`` on your system, add the ``clamav`` class to
+    your system's class list.
+  * See the SIMP ``clamav`` module README for information on managing ``ClamAV``.
 
 * Tue Sep 03 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.4.0-0
 - The following are now optional:

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Oct 29 2019 Jeanne Greulich <jeannegreulich@onyxpoint.com> - 1.4.0-0
+- Remove the clamav catalyst because clamav is not longer included
+  in the class list of the  simp scenarios.
+
 * Tue Sep 03 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.4.0-0
 - The following are now optional:
   - simp_options::puppet::server

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 * Tue Oct 29 2019 Jeanne Greulich <jeannegreulich@onyxpoint.com> - 1.4.0-0
-- Remove the clamav catalyst because clamav is not longer included
-  in the class list of the  simp scenarios.
+- Mark the clamav catalyst as deprecated. As of SIMP 6.5 clamav is no
+  longer included in the class list of the simp scenarios so this
+  catalyst is not needed to disable it.
 
 * Tue Sep 03 2019 Trevor Vaughan <tvaughan@onyxpoint.com> - 1.4.0-0
 - The following are now optional:

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -48,11 +48,12 @@ Default value: `false`
 Data type: `Boolean`
 
 Deprecated. Whether SIMP should manage ``ClamAV``
-This parameter is deprecated and will be removed in later
-releases.  The ``clamav`` class is no longer included by default on simp systems.
-To have simp manage ``ClamAV`` on your systems the ``clamav`` class must
-be added to your systems class list.
-See the simp ``clamav`` module README for information on managing ``ClamAV``.
+This parameter is deprecated and will be removed in later releases.
+SIMP's ``clamav`` class is no longer included by default on SIMP systems.
+To have SIMP manage ``ClamAV`` on your system include the ``clamav`` class
+to your system's class list.
+
+See SIMP's ``clamav`` module README for information on managing ``ClamAV``.
 
 Default value: `false`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -49,8 +49,10 @@ Data type: `Boolean`
 
 Deprecated. Whether SIMP should manage ``ClamAV``
 This parameter is deprecated and will be removed in later
-releases.  ``clamav`` is no longer in the default list of classes in any
-simp scenario.
+releases.  The ``clamav`` class is no longer included by default on simp systems.
+To have simp manage ``ClamAV`` on your systems the ``clamav`` class must
+be added to your systems class list.
+See the simp ``clamav`` module README for information on managing ``ClamAV``.
 
 Default value: `false`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,6 +4,11 @@
 # @param auditd Whether to include SIMP's ``::auditd`` class and add audit rules
 #   pertinent to each application
 #
+# @param clamav  (deprecated) Whether SIMP should manage ``ClamAV``
+#    This parameter is deprecated and will be removed in later
+#    releases.  ``clamav`` is no longer in the default list of classes in any
+#    simp scenario.
+#
 # @param fips Whether to enable ``FIPS`` mode for the system.
 #
 #  This parameter enforces strict compliance with ``FIPS-140-2``.
@@ -73,6 +78,7 @@
 #
 class simp_options (
   Boolean                       $auditd         = false,
+  Boolean                       $clamav         = false,
   Boolean                       $fips           = false,
   Boolean                       $firewall       = false,
   Boolean                       $haveged        = false,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,8 +4,6 @@
 # @param auditd Whether to include SIMP's ``::auditd`` class and add audit rules
 #   pertinent to each application
 #
-# @param clamav Whether SIMP should manage ``ClamAV``
-#
 # @param fips Whether to enable ``FIPS`` mode for the system.
 #
 #  This parameter enforces strict compliance with ``FIPS-140-2``.
@@ -75,7 +73,6 @@
 #
 class simp_options (
   Boolean                       $auditd         = false,
-  Boolean                       $clamav         = false,
   Boolean                       $fips           = false,
   Boolean                       $firewall       = false,
   Boolean                       $haveged        = false,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,9 @@
 # @param clamav  (deprecated) Whether SIMP should manage ``ClamAV``
 #    This parameter is deprecated and will be removed in later
 #    releases.  ``clamav`` is no longer in the default list of classes in any
-#    simp scenario.
+#    simp scenario and the catalyst is not needed.  You now need to include clamav
+#    in your class list to manage it. See pupmod-simp-clamav  README for information on configuring
+#    clamav.
 #
 # @param fips Whether to enable ``FIPS`` mode for the system.
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -5,11 +5,12 @@
 #   pertinent to each application
 #
 # @param clamav  Deprecated. Whether SIMP should manage ``ClamAV``
-#    This parameter is deprecated and will be removed in later
-#    releases.  The ``clamav`` class is no longer included by default on simp systems.
-#    To have simp manage ``ClamAV`` on your systems the ``clamav`` class must
-#    be added to your systems class list.
-#    See the simp ``clamav`` module README for information on managing ``ClamAV``.
+#    This parameter is deprecated and will be removed in later releases.
+#    SIMP's ``clamav`` class is no longer included by default on SIMP systems.
+#    To have SIMP manage ``ClamAV`` on your system include the ``clamav`` class
+#    to your system's class list.
+#
+#    See SIMP's ``clamav`` module README for information on managing ``ClamAV``.
 #
 # @param fips Whether to enable ``FIPS`` mode for the system.
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,10 +6,10 @@
 #
 # @param clamav  Deprecated. Whether SIMP should manage ``ClamAV``
 #    This parameter is deprecated and will be removed in later
-#    releases.  ``clamav`` is no longer in the default list of classes in any
-#    simp scenario and the catalyst is not needed.  You now need to include clamav
-#    in your class list to manage it. See pupmod-simp-clamav  README for information on configuring
-#    clamav.
+#    releases.  The ``clamav`` class is no longer included by default on simp systems.
+#    To have simp manage ``ClamAV`` on your systems the ``clamav`` class must
+#    be added to your systems class list.
+#    See the simp ``clamav`` module README for information on managing ``ClamAV``.
 #
 # @param fips Whether to enable ``FIPS`` mode for the system.
 #


### PR DESCRIPTION
- mark simp_options::clamav as deprecated