### PR TITLE
(SIMP-9519) GLCI: Upgrade build test to pup6+pdk

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -296,7 +296,7 @@ variables:
 #=======================================================================
 
 releng_checks:
-  <<: *pup_5_x
+  <<: *pup_6_x
   <<: *setup_bundler_env
   stage: 'validation'
   tags: ['docker']
@@ -307,7 +307,8 @@ releng_checks:
     - 'bundle exec rake pkg:check_version'
     - 'bundle exec rake pkg:compare_latest_tag'
     - 'bundle exec rake pkg:create_tag_changelog'
-    - 'bundle exec puppet module build'
+    - 'bundle exec pdk build --force --target-dir=dist'
+
 
 # Linting
 #-----------------------------------------------------------------------

--- a/.pmtignore
+++ b/.pmtignore
@@ -7,21 +7,25 @@
 # The next baseline sync will overwrite any local changes made to this file.
 # ------------------------------------------------------------------------------
 .*.sw?
-.yardoc
-dist/
-pkg/
-spec/defines/
-spec/fixtures/
-spec/acceptance/
-spec/rp_env/
-!/spec/hieradata/default.yaml
-!/spec/fixtures/site.pp
+.bundle/
+.git/
+.github/
+.gitlab-ci.yml
 .rspec_system
 .vagrant/
-.bundle/
+.vendor/
+.yardoc
+dist/
+doc/
 Gemfile.lock
-vendor/
 junit/
 log/
-doc/
+pkg/
+spec/acceptance/
+spec/defines/
+spec/fixtures/
+spec/rp_env/
+!/spec/fixtures/site.pp
+!/spec/hieradata/default.yaml
 tests/
+vendor/

--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :test do
   gem 'puppet-lint-trailing_comma-check', :require => false
   gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
   gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.11.5', '< 6']
-  gem( 'pdk', ENV['PDK_VERSION'] || '~> 1.0', :require => false) if major_puppet_version > 5
+  gem( 'pdk', ENV['PDK_VERSION'] || '~> 2.0', :require => false) if major_puppet_version > 5
   gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
 end
 


### PR DESCRIPTION
This patch upgrades the GLCI RELENG check's  puppet module build tests
to use Puppet 6 + `pdk build`, replacing (the now EOL) Puppet 5 and
(the deprecated and removed) `puppet module build`.  It also bumps the
Gemfile's minimum PDK version to 2.0+.

(This patch enforces the standardized asset baseline using
simp/puppetsync, and may apply other updates to ensure conformity.)

CI: SKIP MATRIX
[SIMP-9579] #close
[SIMP-9519] #comment Use GLCI pup6+pdk in pupmod-simp-simp_options

[SIMP-9579]: https://simp-project.atlassian.net/browse/SIMP-9579
[SIMP-9519]: https://simp-project.atlassian.net/browse/SIMP-9519