### PR TITLE
Remove references to archived SIMP modules

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -45,7 +45,6 @@ The following parameters are available in the `simp_options` class:
 * [`sssd`](#-simp_options--sssd)
 * [`stunnel`](#-simp_options--stunnel)
 * [`syslog`](#-simp_options--syslog)
-* [`tcpwrappers`](#-simp_options--tcpwrappers)
 * [`trusted_nets`](#-simp_options--trusted_nets)
 * [`package_ensure`](#-simp_options--package_ensure)
 * [`libkv`](#-simp_options--libkv)
@@ -192,16 +191,6 @@ Default value: `false`
 Data type: `Boolean`
 
 Include SIMP's ``rsyslog`` class and configure RSyslog application hooks
-
-Default value: `false`
-
-##### <a name="-simp_options--tcpwrappers"></a>`tcpwrappers`
-
-Data type: `Boolean`
-
-Whether to include SIMP's ``tcpwrappers`` class and use
-``tcpwrappers::allow`` to permit the application to the subnets in
-``$simp_options::trusted_nets``
 
 Default value: `false`
 

--- a/SIMP/compliance_profiles/checks.yaml
+++ b/SIMP/compliance_profiles/checks.yaml
@@ -329,27 +329,6 @@ checks:
         - CCI-001744
         - CCI-000366
         - SRG-OS-000363-GPOS-00150
-  oval:com.puppet.forge.simp.simp_options.tcpwrappers:
-    settings:
-      parameter: simp_options::tcpwrappers
-      value: true
-    type: puppet-class-parameter
-    controls:
-      nist_800_53:rev4: true
-      nist_800_53:rev4:AC-4: true
-      disa_stig: true
-      AC-4: true
-      RHEL-07-040810: true
-      SRG-OS-000480-GPOS-00227: true
-      cci:CCI-000366: true
-    identifiers:
-      nist_800_53:rev4:
-        - AC-4
-      disa_stig:
-        - AC-4
-        - RHEL-07-040810
-        - SRG-OS-000480-GPOS-00227
-        - CCI-000366
   oval:com.puppet.forge.simp.simp_options.uid.max:
     settings:
       parameter: simp_options::uid::max

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -70,11 +70,6 @@
 # @param syslog
 #   Include SIMP's ``rsyslog`` class and configure RSyslog application hooks
 #
-# @param tcpwrappers
-#   Whether to include SIMP's ``tcpwrappers`` class and use
-#   ``tcpwrappers::allow`` to permit the application to the subnets in
-#   ``$simp_options::trusted_nets``
-#
 # @param trusted_nets
 #   Subnets to permit, in ``CIDR`` notation
 #
@@ -107,7 +102,6 @@ class simp_options (
   Boolean                       $sssd           = false,
   Boolean                       $stunnel        = false,
   Boolean                       $syslog         = false,
-  Boolean                       $tcpwrappers    = false,
   Simplib::Netlist              $trusted_nets   = ['127.0.0.1', '::1'],
   String                        $package_ensure = 'latest',
   Boolean                       $libkv          = false


### PR DESCRIPTION
Remove all references to the following archived modules: chkrootkit, hirs_provisioner, incron, network, rkhunter, simp_bolt, simp_ipa, simp_openldap, simp_pki_service, sudosh, tcpwrappers, tpm, xinetd

This includes removal from metadata.json dependencies, .fixtures.yml, Puppetfiles, manifests, spec tests, hiera data, and acceptance tests as applicable.