### PR TITLE
Prepare 2.0.0 release

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -8,26 +8,13 @@
 #
 # ==============================================================================
 #
-# The testing matrix considers ruby/puppet versions supported by SIMP and PE:
-# ------------------------------------------------------------------------------
-# Release       Puppet   Ruby    EOL
-# PE 2019.8     6.22     2.5     2022-12 (LTS)
-# PE 2021.Y     7.x      2.7     Quarterly updates
-#
-# https://puppet.com/docs/pe/latest/component_versions_in_recent_pe_releases.html
-# https://puppet.com/misc/puppet-enterprise-lifecycle
-# ==============================================================================
-#
 # https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 #
-
+---
 name: PR Tests
-on:
+'on':
   pull_request:
     types: [opened, reopened, synchronize]
-
-env:
-  PUPPET_VERSION: '~> 7'
 
 jobs:
   puppet-syntax:
@@ -35,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: "Install Ruby 2.7"
+      - name: "Install Ruby 3.2"
         uses: ruby/setup-ruby@v1  # ruby/setup-ruby@ec106b438a1ff6ff109590de34ddc62c540232e0
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.2.11
           bundler-cache: true
       - run: "bundle exec rake syntax"
 
@@ -47,10 +34,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: "Install Ruby 2.7"
+      - name: "Install Ruby 3.2"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.2.11
           bundler-cache: true
       - run: "bundle exec rake lint"
       - run: "bundle exec rake metadata_lint"
@@ -61,10 +48,10 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v6
-      - name: "Install Ruby 2.7"
+      - name: "Install Ruby 3.4"
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.4.9
           bundler-cache: true
       - run: |
           bundle show
@@ -75,10 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: 'Install Ruby 2.7'
+      - name: 'Install Ruby 3.4'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.4.9
           bundler-cache: true
       - run: bundle exec rake check:dot_underscore
       - run: bundle exec rake check:test_file
@@ -88,10 +75,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: 'Install Ruby 2.7'
+      - name: 'Install Ruby 3.4'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.4.9
           bundler-cache: true
       - name: 'Tags and changelogs'
         run: |
@@ -108,10 +95,6 @@ jobs:
     strategy:
       matrix:
         puppet:
-          - label: 'Puppet 7.x [SIMP 6.6/PE 2021.7]'
-            puppet_version: '~> 7.0'
-            ruby_version: '2.7'
-            experimental: false
           - label: 'Puppet 8.x'
             puppet_version: '~> 8.0'
             ruby_version: '3.2'

--- a/.github/workflows/tag_deploy.yml
+++ b/.github/workflows/tag_deploy.yml
@@ -39,7 +39,7 @@ on:
       - '[0-9]+\.[0-9]+\.[0-9]+\-[a-z]+[0-9]+'
 
 env:
-  PUPPET_VERSION: '~> 7'
+  PUPPET_VERSION: '~> 8'
 
 jobs:
   releng-checks:
@@ -55,7 +55,7 @@ jobs:
           clean: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.4.9
           bundler-cache: true
       - run: bundle exec rake pkg:check_version
       - run: bundle exec rake pkg:compare_latest_tag
@@ -180,7 +180,7 @@ jobs:
           clean: true
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.8
+          ruby-version: 3.4.9
           bundler-cache: true
       - name: Build Puppet module (PDK)
         run: bundle exec pdk build --force

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,11 @@
-* Mon May 11 2026 Steven Pritchard <steve@sicura.us> - 2.0.0
+* Fri May 22 2026 Steven Pritchard <steve@sicura.us> - 2.0.0
 - Remove unmaintained Compliance Engine data
+- Drop support for Puppet 7 (Puppet 8 is now the minimum)
+- Switch supported runtime from `puppet` to `openvox` in metadata.json
+- Drop support for EL7 (CentOS, RHEL, OracleLinux) and CentOS 8
+- Add support for EL10 (CentOS, RHEL, OracleLinux, Rocky, AlmaLinux)
+- Update `issues_url` to the GitHub issues page
+- Allow `simp/simplib` 5.x
 
 * Mon Oct 23 2023 Steven Pritchard <steve@sicura.us> - 1.10.0
 - [puppetsync] Add EL9 support

--- a/Gemfile
+++ b/Gemfile
@@ -20,13 +20,16 @@ group :syntax do
 end
 
 group :test do
-  puppet_version = ENV.fetch('PUPPET_VERSION', ['>= 7', '< 9'])
+  puppet_version = ENV.fetch('PUPPET_VERSION', ['>= 8', '< 9'])
+  openvox_version = ENV.fetch('OPENVOX_VERSION', puppet_version)
   major_puppet_version = Array(puppet_version).first.scan(%r{(\d+)(?:\.|\Z)}).flatten.first.to_i
   gem 'hiera-puppet-helper'
-  gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   # renovate: datasource=rubygems versioning=ruby
   gem('pdk', ENV.fetch('PDK_VERSION', ['>= 2.0', '< 4.0']), require: false) if major_puppet_version > 5
-  gem 'puppet', puppet_version
+  # Temporarily include both openvox and puppet gems until the puppet dependency is removed from other gems
+  ['openvox', 'puppet'].each do |gem_name|
+    gem gem_name, binding.local_variable_get("#{gem_name}_version".to_sym)
+  end
   gem 'puppetlabs_spec_helper', '~> 8.0.0'
   gem 'puppet-strings'
   gem 'rake'

--- a/metadata.json
+++ b/metadata.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "source": "https://github.com/simp/pupmod-simp-simp_options",
   "project_page": "https://github.com/simp/pupmod-simp-simp_options",
-  "issues_url": "https://simp-project.atlassian.net",
+  "issues_url": "https://github.com/simp/pupmod-simp-simp_options/issues",
   "tags": [
     "simp"
   ],
@@ -17,53 +17,54 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 4.9.0 < 5.0.0"
+      "version_requirement": ">= 4.9.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "8",
-        "7",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
         "8",
-        "7",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "OracleLinux",
       "operatingsystemrelease": [
         "8",
-        "7",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "Rocky",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     },
     {
       "operatingsystem": "AlmaLinux",
       "operatingsystemrelease": [
         "8",
-        "9"
+        "9",
+        "10"
       ]
     }
   ],
   "requirements": [
     {
-      "name": "puppet",
-      "version_requirement": ">= 7.0.0 < 9.0.0"
+      "name": "openvox",
+      "version_requirement": ">= 8.0.0 < 9.0.0"
     }
   ]
 }


### PR DESCRIPTION
- metadata.json: point issues_url to GitHub; drop EL7 (CentOS/RHEL/Oracle) and CentOS 8; add EL10 across all supported distros; replace `puppet` requirement with `openvox` (>= 8, < 9); allow simp/simplib 5.x.
- Gemfile: default PUPPET_VERSION to '>= 8', include both `openvox` and `puppet` gems (mirroring the pupmod-simp-aide baseline).
- Workflows: drop Puppet 7 / Ruby 2.7; use Ruby 3.2.11 for Puppet 8 spec tests and Ruby 3.4.9 elsewhere; set tag_deploy PUPPET_VERSION to '~> 8'.
- CHANGELOG: summarize user-visible changes in the 2.0.0 entry.