### PR TITLE
Fix openssl::params compilation on non-Linux kernels

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+* Thu Jul 16 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 2.0.2
+- Fix `simp_options::openssl::params` catalog compilation failure on
+  non-Linux nodes when FIPS is enabled (the `fips_ciphers` fact is only
+  provided on Linux)
+
 * Thu Jul 09 2026 Steven Pritchard <steve@sicura.us> - 2.0.1
 - Resolved puppet-lint manifest whitespace offenses
 

--- a/manifests/openssl/params.pp
+++ b/manifests/openssl/params.pp
@@ -7,7 +7,7 @@ class simp_options::openssl::params (
   assert_private()
   include 'simp_options'
 
-  if $simp_options::fips or $facts['fips_enabled'] {
+  if $facts['kernel'] == 'Linux' and ($simp_options::fips or $facts['fips_enabled']) {
     if $facts['fips_ciphers'] {
       $cipher_suite = $facts['fips_ciphers']
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-simp_options",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "author": "SIMP Team",
   "summary": "Variables enabling SIMP core capabilities",
   "license": "Apache-2.0",

--- a/spec/classes/openssl_spec.rb
+++ b/spec/classes/openssl_spec.rb
@@ -14,7 +14,7 @@ describe 'simp_options' do
         end
 
         context 'defaults for simp_options::openssl with FIPS enabled and the fips_ciphers fact unavailable' do
-          let(:facts) { { fips_enabled: true } }
+          let(:facts) { { kernel: 'Linux', fips_enabled: true } }
 
           it { expect { is_expected.to compile.with_all_deps }.to raise_error(%r{not found}) }
         end
@@ -22,8 +22,9 @@ describe 'simp_options' do
         context 'defaults for simp_options::openssl with FIPS enabled and the fips_ciphers fact available' do
           let(:facts) do
             {
+              kernel: 'Linux',
               fips_enabled: true,
-           fips_ciphers: ['ECDHE-RSA-AES256-GCM-SHA384', 'ECDHE-ECDSA-AES256-GCM-SHA384', 'other totally legit FIPS cipher']
+              fips_ciphers: ['ECDHE-RSA-AES256-GCM-SHA384', 'ECDHE-ECDSA-AES256-GCM-SHA384', 'other totally legit FIPS cipher']
             }
           end
 
@@ -31,6 +32,17 @@ describe 'simp_options' do
           it {
             is_expected.to contain_class('simp_options::openssl').with(
               cipher_suite: ['ECDHE-RSA-AES256-GCM-SHA384', 'ECDHE-ECDSA-AES256-GCM-SHA384', 'other totally legit FIPS cipher'],
+            )
+          }
+        end
+
+        context 'defaults for simp_options::openssl with FIPS enabled on a non-Linux kernel' do
+          let(:facts) { { kernel: 'windows', fips_enabled: true } }
+
+          it { is_expected.to compile.with_all_deps }
+          it {
+            is_expected.to contain_class('simp_options::openssl').with(
+              cipher_suite: ['DEFAULT', '!MEDIUM'],
             )
           }
         end


### PR DESCRIPTION
Gate the FIPS cipher lookup on kernel == 'Linux' so Windows nodes (where the fips_ciphers fact does not exist) fall through to the default cipher suite instead of failing catalog compilation.

Fixes #83