### PR TITLE
Remove deprecated clamav and tcpwrappers catalyst parameters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,12 @@
   set `simp_options::ntpd::servers` in hieradata MUST rename the key to
   `simp_options::ntp::servers`, which is consumed by the chrony replacement
   and by the SIMP client kickstart
+- BREAKING CHANGE: Remove the `simp_options::clamav` catalyst parameter,
+  which has been marked "Deprecated - DO NOT USE" (pupmod-simp-simp 9.0.0
+  drops its ClamAV support)
+- BREAKING CHANGE: Remove the `simp_options::tcpwrappers` catalyst parameter
+  (pupmod-simp-tcpwrappers is archived and TCP wrappers does not exist on
+  any supported EL release)
 
 * Thu Jul 16 2026 Nicholas Markowski <nicholas.markowski@onyxpoint.com> - 2.0.2
 - Fix `simp_options::openssl::params` catalog compilation failure on

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -30,7 +30,6 @@ Sets up variables that enable core SIMP capabilities or provide site configurati
 The following parameters are available in the `simp_options` class:
 
 * [`auditd`](#-simp_options--auditd)
-* [`clamav`](#-simp_options--clamav)
 * [`fips`](#-simp_options--fips)
 * [`firewall`](#-simp_options--firewall)
 * [`haveged`](#-simp_options--haveged)
@@ -44,7 +43,6 @@ The following parameters are available in the `simp_options` class:
 * [`sssd`](#-simp_options--sssd)
 * [`stunnel`](#-simp_options--stunnel)
 * [`syslog`](#-simp_options--syslog)
-* [`tcpwrappers`](#-simp_options--tcpwrappers)
 * [`trusted_nets`](#-simp_options--trusted_nets)
 * [`package_ensure`](#-simp_options--package_ensure)
 * [`libkv`](#-simp_options--libkv)
@@ -55,14 +53,6 @@ Data type: `Boolean`
 
 Include SIMP's ``auditd`` class and add audit rules pertinent to each
 application
-
-Default value: `false`
-
-##### <a name="-simp_options--clamav"></a>`clamav`
-
-Data type: `Boolean`
-
-Deprecated - DO NOT USE
 
 Default value: `false`
 
@@ -191,16 +181,6 @@ Default value: `false`
 Data type: `Boolean`
 
 Include SIMP's ``rsyslog`` class and configure RSyslog application hooks
-
-Default value: `false`
-
-##### <a name="-simp_options--tcpwrappers"></a>`tcpwrappers`
-
-Data type: `Boolean`
-
-Whether to include SIMP's ``tcpwrappers`` class and use
-``tcpwrappers::allow`` to permit the application to the subnets in
-``$simp_options::trusted_nets``
 
 Default value: `false`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,9 +4,6 @@
 #   Include SIMP's ``auditd`` class and add audit rules pertinent to each
 #   application
 #
-# @param clamav
-#   Deprecated - DO NOT USE
-#
 # @param fips
 #   Enable ``FIPS`` mode for the system
 #
@@ -70,11 +67,6 @@
 # @param syslog
 #   Include SIMP's ``rsyslog`` class and configure RSyslog application hooks
 #
-# @param tcpwrappers
-#   Whether to include SIMP's ``tcpwrappers`` class and use
-#   ``tcpwrappers::allow`` to permit the application to the subnets in
-#   ``$simp_options::trusted_nets``
-#
 # @param trusted_nets
 #   Subnets to permit, in ``CIDR`` notation
 #
@@ -94,7 +86,6 @@
 class simp_options (
   Boolean                       $auditd         = false,
   Boolean                       $authselect     = false,
-  Boolean                       $clamav         = false,
   Boolean                       $fips           = false,
   Boolean                       $firewall       = false,
   Boolean                       $haveged        = false,
@@ -107,7 +98,6 @@ class simp_options (
   Boolean                       $sssd           = false,
   Boolean                       $stunnel        = false,
   Boolean                       $syslog         = false,
-  Boolean                       $tcpwrappers    = false,
   Simplib::Netlist              $trusted_nets   = ['127.0.0.1', '::1'],
   String                        $package_ensure = 'latest',
   Boolean                       $libkv          = false


### PR DESCRIPTION
Stacked on #129 to ride the same 3.0.0 major bump: removes the `simp_options::clamav` catalyst parameter (marked "Deprecated - DO NOT USE"; pupmod-simp-simp 9.0.0 drops its ClamAV support) and the `simp_options::tcpwrappers` catalyst parameter (`pupmod-simp-tcpwrappers` is archived and TCP wrappers does not exist on any supported EL release), along with their REFERENCE.md entries and CHANGELOG bullets. Neither parameter was consumed inside this module, and downstream `simplib::lookup` callers are unaffected (the hiera keys simply resolve to their defaults). Retarget to master once #129 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)