### PR TITLE
Verify that simp_options::ntp rejects malformed server addresses

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -17,7 +17,7 @@
     },
     {
       "name": "simp/simplib",
-      "version_requirement": ">= 4.9.0 < 6.0.0"
+      "version_requirement": ">= 4.9.0 < 8.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/classes/ntp_spec.rb
+++ b/spec/classes/ntp_spec.rb
@@ -34,6 +34,22 @@ describe 'simp_options' do
         )
         }
       end
+
+      # The Simplib::Host elements of $servers must reject a dotted-decimal
+      # address with an out-of-range octet. This requires simp/simplib 7.0.0
+      # or later; before that, Simplib::Hostname matched '1.2.3.400' as a
+      # host name. See simp/pupmod-simp-simplib#351.
+      context 'invalid ntp servers' do
+        let(:hieradata) { 'simp_options_with_invalid_ntp_servers' }
+
+        it { is_expected.not_to compile.with_all_deps }
+      end
+
+      context 'invalid ntp servers in a hash' do
+        let(:hieradata) { 'simp_options_with_invalid_ntp_hash' }
+
+        it { is_expected.not_to compile.with_all_deps }
+      end
     end
   end
 end

--- a/spec/fixtures/hieradata/simp_options_with_invalid_ntp_hash.yaml
+++ b/spec/fixtures/hieradata/simp_options_with_invalid_ntp_hash.yaml
@@ -1,0 +1,4 @@
+---
+simp_options::ntp::servers:
+  '1.2.3.400':
+    - 'iburst'

--- a/spec/fixtures/hieradata/simp_options_with_invalid_ntp_servers.yaml
+++ b/spec/fixtures/hieradata/simp_options_with_invalid_ntp_servers.yaml
@@ -1,0 +1,3 @@
+---
+simp_options::ntp::servers:
+  - '1.2.3.400'


### PR DESCRIPTION
> [!IMPORTANT]
> Blocked on simp/pupmod-simp-simplib#352. Opened as a draft — the new examples fail against simplib `master` today. Ready to mark for review as soon as that merges.

`simp_options::ntp` types its `$servers` as `Simplib::Host` — either as an array, or as the keys of a hash — but nothing asserted that a malformed address is actually rejected. The deprecated `simp_options::ntpd` class did have that coverage, through a fixture that set `1.2.3.400`.

This came up while reviewing #129, which removes `simp_options::ntpd` and its spec. One of the removed examples has no counterpart in `ntp_spec.rb`:

```ruby
context 'invalid ntpd servers' do
  let(:hieradata) { 'simp_options_with_invalid_ntpd_servers' }

  it { is_expected.not_to compile.with_all_deps }
end
```

(The other removed example, the default-parameters case, is already covered by `ntp_spec.rb`.)

This PR adds the equivalent coverage for `simp_options::ntp`, in both the array and hash forms, since the hash keys are `Simplib::Host` too and had the same gap.

## Why this needs simplib 7.0.0

`simp_options::ntpd` validated with `simplib::validate_net_list`. `simp_options::ntp` deliberately does not — it relies on the type, which is the right call now that Puppet has strong typing. But the type did not hold up its end: `Simplib::Hostname` matched `1.2.3.400` as a *host name*, so `Simplib::Host` accepted it and the catalog compiled.

That is fixed in simp/pupmod-simp-simplib#352 (simp/pupmod-simp-simplib#351). With that fix, the new examples pass on the type alone, with no validation function involved.

This is a testing requirement, satisfied by `.fixtures.yml`, rather than a runtime compatibility constraint — `simp_options::ntp` itself works against the full declared dependency range.

Verified locally against a patched simplib: **85 examples, 0 failures**. Against simplib `master`: the `invalid ntp servers` example fails, as expected.

## Two things for the maintainer to decide

1. **Version bump and CHANGELOG.** Deliberately left out. #129 already claims `3.0.0`, and picking a number here would collide depending on merge order. Happy to add whichever is right once the sequencing is settled.

2. **`.gitignore` prevents adding hieradata fixtures.** The two new fixtures had to be committed with `git add -f`:

   ```
   /spec/fixtures/*
   # Un-ignore hieradata
   !/spec/fixtures/hieradata/*
   ```

   Git cannot re-include a path whose parent directory is excluded, so `/spec/fixtures/*` excludes the `hieradata` directory itself and the negation never takes effect. Existing fixtures are unaffected only because they are already tracked. Any new hieradata fixture in any module is silently ignored.

   `.gitignore` is puppetsync-managed, so I have not touched it here. The fix belongs in the puppetsync baseline — adding `!/spec/fixtures/hieradata/` (the directory) ahead of the existing file-level negation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
