### PR TITLE
[puppetsync] Add a REFERENCE.md freshness check to PR tests

### DIFF
--- a/.github/workflows/pr_tests.yml
+++ b/.github/workflows/pr_tests.yml
@@ -70,6 +70,19 @@ jobs:
       - run: bundle exec rake check:dot_underscore
       - run: bundle exec rake check:test_file
 
+  reference:
+    name: 'REFERENCE.md freshness'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: 'Install Ruby 3.4'
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.4.9
+          bundler-cache: true
+      - name: 'Check REFERENCE.md freshness'
+        run: bundle exec rake validate:strings
+
   releng-checks:
     name: 'RELENG checks'
     runs-on: ubuntu-latest
@@ -120,15 +133,6 @@ jobs:
           ruby-version: ${{matrix.puppet.ruby_version}}
           bundler-cache: true
       - run: 'command -v rpm || if command -v apt-get; then sudo apt-get update; sudo apt-get install -y rpm; fi ||:'
-      - run: 'bundle exec rake spec'
+      - run: 'bundle exec rake parallel_spec'
         continue-on-error: ${{matrix.puppet.experimental}}
 
-#  dump_contexts:
-#    name: 'Examine Context contents'
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Dump contexts
-#        env:
-#          GITHUB_CONTEXT: ${{ toJson(github) }}
-#        run: echo "$GITHUB_CONTEXT"
-#

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -463,7 +463,7 @@ Data type: `Array[String]`
 
 The default ciphers to use in openssl.
 
-Default value: `$::simp_options::openssl::params::cipher_suite`
+Default value: `$simp_options::openssl::params::cipher_suite`
 
 ### <a name="simp_options--openssl--params"></a>`simp_options::openssl::params`
 


### PR DESCRIPTION
This patch updates pr_tests.yml from the reconciled puppetsync
template, whose `reference` job now fails when REFERENCE.md is out
of sync with the module's strings docs (`rake validate:strings`),
and regenerates REFERENCE.md so the new check starts green.

Repo-specific `jobs.acceptance` blocks are preserved as-is.